### PR TITLE
Bug fix: MultiSlider bottom bound can become greater than top bound

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -122,7 +122,8 @@ export default class MultiSlider extends React.Component {
     moveOne = (gestureState) => {
       var unconfined = gestureState.dx + this.state.pastOne;
       var bottom     = 0;
-      var top        = (this.state.positionTwo - this.stepLength) || this.props.sliderLength;
+      var trueTop    = this.state.positionTwo - this.stepLength;
+      var top        = (trueTop === 0) ? 0 : trueTop || this.props.sliderLength;
       var confined   = unconfined < bottom ? bottom : (unconfined > top ? top : unconfined);
       var value      = positionToValue(this.state.positionOne, this.optionsArray, this.props.sliderLength);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Tomas Roos <ptomasroos@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-     "react-native": "^0.27.2",
+     "react-native": ">=0.27.2",
      "react": "^15.1.0"
    },
    "devDependencies": {


### PR DESCRIPTION
-  Fix a logic error that allows bottom bound to exceed top bound
- Updated the `react-native` peerDependency as well. 


---

Issue:

I have a MultiSlider with props: `min={0} max={75} values={[0,75]}`. 

- When I drag the top bound all the way left the values become: `[0,5]`
- Then drag the bottom bound to the right... and you'll see the issue. 
- Bottom bound becomes higher than top bound (i.e. values become: `[40,5]`)

See: 

![screen recording 2016-07-18 at 04 57 pm](https://cloud.githubusercontent.com/assets/746320/16930096/c984ba96-4d08-11e6-832c-88741fcf531c.gif)
