### PR TITLE
Passing the current value to the marker 

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -254,6 +254,7 @@ export default class MultiSlider extends React.Component {
                   pressed={this.state.onePressed}
                   markerStyle={[styles.marker, this.props.markerStyle]}
                   pressedMarkerStyle={this.props.pressedMarkerStyle}
+                  currentValue={this.state.valueOne}
                 />
               </View>
             </View>
@@ -268,6 +269,7 @@ export default class MultiSlider extends React.Component {
                     pressed={this.state.twoPressed}
                     markerStyle={this.props.markerStyle}
                     pressedMarkerStyle={this.props.pressedMarkerStyle}
+                    currentValue={this.state.valueTwo}
                   />
                 </View>
               </View>


### PR DESCRIPTION
I wanted to use a custom marker that leverages the current value:

`<Image
        style={ flex: 1, justifyContent: 'center', alignItems: 'center', height: 40, width: 40 }
        source={this.props.pressed ? require('./image.png') : require('./image2.png')}
        resizeMode='contain'
      >
      <Text style={{backgroundColor: 'transparent', color: '#eee'}}>{this.props.currentValue}</Text>
      </Image>`

Passing in the current value state to the marker as a prop allows for this use case. I realize the thumb might get in the way but this is just a simple example.