### PR TITLE
chore(proptypes): prepare to React 16

### DIFF
--- a/DefaultMarker.js
+++ b/DefaultMarker.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import { View, StyleSheet, Platform, TouchableHighlight, ViewPropTypes } from 'react-native';
 

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   StyleSheet,

--- a/package.json
+++ b/package.json
@@ -23,17 +23,19 @@
   "author": "Tomas Roos <ptomasroos@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-     "react-native": "*",
-     "react": "*"
-   },
-   "devDependencies": {
-     "babel-eslint": "7.2.3",
-     "eslint": "3.19.0",
-     "eslint-config-airbnb": "14.1.0",
-     "eslint-plugin-import": "2.2.0",
-     "eslint-plugin-jsx-a11y": "4.0.0",
-     "eslint-plugin-react": "6.10.3"
-   },
+    "react-native": "*",
+    "react": "*",
+    "prop-types": "*"
+  },
+  "devDependencies": {
+    "babel-eslint": "7.2.3",
+    "eslint": "3.19.0",
+    "eslint-config-airbnb": "14.1.0",
+    "eslint-plugin-import": "2.2.0",
+    "eslint-plugin-jsx-a11y": "4.0.0",
+    "eslint-plugin-react": "6.10.3"
+
+  },
   "bugs": {
     "url": "https://github.com/ptomasroos/react-native-multi-slider/issues"
   },


### PR DESCRIPTION
When updating to React 16 beta, the App stopped working because PropTypes are no more under the package `react`.

I tried to run the example, but it gets stuck. I also try to build it to test it locally but can't fight the command to use. Could you indicate them? 