### PR TITLE
Added setting of min, max and values to componentWIllReceiveProps

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -131,6 +131,14 @@ export default class MultiSlider extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    if(nextProps.min !== this.props.min && nextProps.max !== this.props.max){
+      this.optionsArray = this.props.optionsArray ||
+        createArray(nextProps.min, nextProps.max, nextProps.step);
+      //this.stepLength = this.props.sliderLength / this.optionsArray.length;
+
+      var initialValues = nextProps.values.map(value =>
+        valueToPosition(value, this.optionsArray, nextProps.sliderLength));
+    }
     if (this.state.onePressed || this.state.twoPressed) {
       return;
     }


### PR DESCRIPTION
This is a proposed fix to enable the min/max/values to be set after the first mounting of the component, in a situation where the app doesn't have the values until they are retrieved from a server this is necessary. Now componentWillReceiveProps will update the values in the component once received.