### PR TITLE
Improve closest function

### DIFF
--- a/converters.js
+++ b/converters.js
@@ -1,5 +1,42 @@
 // Find closest index for a given value
-const closest = (array, n) => array.findIndex((elem) => (n <= elem));
+const closest = (array, n) => {
+  let minI = 0;
+  let maxI = array.length - 1;
+
+  if (array[minI] > n) {
+    return minI;
+  } else if (array[maxI] < n) {
+    return maxI;
+  } else if (array[minI] <= n && n <= array[maxI]) {
+    let closestIndex = null;
+
+    while (closestIndex === null) {
+      const midI = Math.round((minI + maxI) / 2);
+      const midVal = array[midI];
+
+      if (midVal === n) {
+        closestIndex = midI;
+      } else if (maxI === minI + 1) {
+        const minValue = array[minI];
+        const maxValue = array[maxI];
+        const deltaMin = Math.abs(minValue - n);
+        const deltaMax = Math.abs(maxValue - n);
+
+        closestIndex = deltaMax <= deltaMin ? maxI : minI;
+      } else if (midVal < n) {
+        minI = midI;
+      } else if (midVal > n) {
+        maxI = midI;
+      } else {
+        closestIndex = -1;
+      }
+    }
+
+    return closestIndex;
+  }
+
+  return -1;
+};
 
 export function valueToPosition(value, valuesArray, sliderLength) {
   const index = closest(valuesArray, value);


### PR DESCRIPTION
Hi !

I started to use react native multi slider and I figured out that the closest was not very precise - and not very optimised. So I decided to improve it and propose it to you.

**Here is why it is not precise:**
If my initial value is `11` and I have a `step` of `10` between `0` and `100`, it will take the value `20` and not `10` - which is the closest. It is not correct... If you have really large steps, it won't be good enough.

**Here is why it is not very optimised:**
`findIndex` will go through the entire array if the value is at the end - `max` may often be at the end. If you have a large range between `min` and `max` with a tiny `step`, it may be relatively slow.

I saw that we wanted to keep it simple in https://github.com/ptomasroos/react-native-multi-slider/pull/50. I think that my proposition is not very hard to understand since you know that it is a binary search slightly modified.

Tell me what do you think, thanks !

@ptomasroos 