### PR TITLE
fixed the marker getting away from real value when markerOffsetX is provided

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -357,7 +357,7 @@ export default class MultiSlider extends React.Component {
 
     const markerContainerTwo = {
       top: markerOffsetY - 24,
-      right: trackThreeLength + markerOffsetX - 24,
+      right: trackThreeLength - markerOffsetX - 24,
     };
 
     const containerStyle = [styles.container, this.props.containerStyle];


### PR DESCRIPTION
when the slider is used between an elment with padding and margin the markers in android as well as ios are not in the correct position ios looks ok as the markers are bigger but android the difference is evident
<img width="743" alt="screen shot 2018-11-18 at 4 07 20 pm" src="https://user-images.githubusercontent.com/3845645/48680053-0c3a7680-eb4c-11e8-921c-458d2bdbaaf0.png">
this fix this issue as the offsetx must be added to the left marker but subtracted from right as  in case of right the distance is from right  corner
#100 