### PR TITLE
Add prop minMarkerOverlapDistance to allow setting a custom value for how close two markers can get to each other

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -1,19 +1,17 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
 	I18nManager,
 	PanResponder,
 	Platform,
-	StyleSheet,
-	TouchableHighlight,
-	View,
-} from "react-native";
+	I18nManager,
+} from 'react-native';
 
-import DefaultMarker from "./DefaultMarker";
-import { createArray, positionToValue, valueToPosition } from "./converters";
+import DefaultMarker from './DefaultMarker';
+import { createArray, valueToPosition, positionToValue } from './converters';
 
-const ViewPropTypes = require("react-native").ViewPropTypes || View.propTypes;
+const ViewPropTypes = require('react-native').ViewPropTypes || View.propTypes;
 
 export default class MultiSlider extends React.Component {
 	static defaultProps = {
@@ -136,7 +134,7 @@ export default class MultiSlider extends React.Component {
 			nextState.positionTwo = positionTwo;
 		}
 
-		if (nextState !== {}) {
+		if (nextState != {}) {
 			this.setState(nextState);
 		}
 	}
@@ -148,7 +146,7 @@ export default class MultiSlider extends React.Component {
 				onePressed: !this.state.onePressed,
 			});
 		}
-	}
+	};
 
 	startTwo = () => {
 		if (this.props.enabledTwo) {
@@ -157,7 +155,7 @@ export default class MultiSlider extends React.Component {
 				twoPressed: !this.state.twoPressed,
 			});
 		}
-	}
+	};
 
 	moveOne = gestureState => {
 		if (!this.props.enabledOne) {
@@ -217,7 +215,7 @@ export default class MultiSlider extends React.Component {
 				);
 			}
 		}
-	}
+	};
 
 	moveTwo = gestureState => {
 		if (!this.props.enabledTwo) {
@@ -277,7 +275,7 @@ export default class MultiSlider extends React.Component {
 				);
 			}
 		}
-	}
+	};
 
 	endOne = gestureState => {
 		if (gestureState.moveX === 0 && this.props.onToggleOne) {
@@ -298,7 +296,7 @@ export default class MultiSlider extends React.Component {
 				this.props.onValuesChangeFinish(change);
 			},
 		);
-	}
+	};
 
 	endTwo = gestureState => {
 		if (gestureState.moveX === 0 && this.props.onToggleTwo) {
@@ -318,7 +316,7 @@ export default class MultiSlider extends React.Component {
 				]);
 			},
 		);
-	}
+	};
 
 	render() {
 		const { positionOne, positionTwo } = this.state;
@@ -329,7 +327,7 @@ export default class MultiSlider extends React.Component {
 			markerOffsetX,
 			markerOffsetY,
 		} = this.props;
-		const twoMarkers = this.props.values.length === 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
+		const twoMarkers = this.props.values.length == 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
 
 		const trackOneLength = positionOne;
 		const trackOneStyle = twoMarkers
@@ -371,7 +369,7 @@ export default class MultiSlider extends React.Component {
 
 		if (this.props.vertical) {
 			containerStyle.push({
-				transform: [{ rotate: "-90deg" }],
+				transform: [{ rotate: '-90deg' }],
 			});
 		}
 
@@ -486,51 +484,51 @@ export default class MultiSlider extends React.Component {
 
 const styles = StyleSheet.create({
 	container: {
-		position: "relative",
+		position: 'relative',
 		height: 50,
-		justifyContent: "center",
+		justifyContent: 'center',
 	},
 	fullTrack: {
-		flexDirection: "row",
+		flexDirection: 'row',
 	},
 	track: {
 		...Platform.select({
 			ios: {
 				height: 2,
 				borderRadius: 2,
-				backgroundColor: "#A7A7A7",
+				backgroundColor: '#A7A7A7',
 			},
 			android: {
 				height: 2,
-				backgroundColor: "#CECECE",
+				backgroundColor: '#CECECE',
 			},
 		}),
 	},
 	selectedTrack: {
 		...Platform.select({
 			ios: {
-				backgroundColor: "#095FFF",
+				backgroundColor: '#095FFF',
 			},
 			android: {
-				backgroundColor: "#0D8675",
+				backgroundColor: '#0D8675',
 			},
 		}),
 	},
 	markerContainer: {
-		position: "absolute",
+		position: 'absolute',
 		width: 48,
 		height: 48,
-		backgroundColor: "transparent",
-		justifyContent: "center",
-		alignItems: "center",
+		backgroundColor: 'transparent',
+		justifyContent: 'center',
+		alignItems: 'center',
 	},
 	topMarkerContainer: {
 		zIndex: 1,
 	},
 	touch: {
-		backgroundColor: "transparent",
-		justifyContent: "center",
-		alignItems: "center",
-		alignSelf: "stretch",
+		backgroundColor: 'transparent',
+		justifyContent: 'center',
+		alignItems: 'center',
+		alignSelf: 'stretch',
 	},
 });

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
 import {
 	StyleSheet,
@@ -8,12 +8,12 @@ import {
 	TouchableHighlight,
 	Platform,
 	I18nManager,
-} from 'react-native';
+} from "react-native";
 
-import DefaultMarker from './DefaultMarker';
-import { createArray, valueToPosition, positionToValue } from './converters';
+import DefaultMarker from "./DefaultMarker";
+import { createArray, valueToPosition, positionToValue } from "./converters";
 
-const ViewPropTypes = require('react-native').ViewPropTypes || View.propTypes;
+const ViewPropTypes = require("react-native").ViewPropTypes || View.propTypes;
 
 export default class MultiSlider extends React.Component {
 	static defaultProps = {
@@ -135,7 +135,7 @@ export default class MultiSlider extends React.Component {
 			nextState.positionTwo = positionTwo;
 		}
 
-		if (nextState != {}) {
+		if (nextState !== {}) {
 			this.setState(nextState);
 		}
 	}
@@ -147,7 +147,7 @@ export default class MultiSlider extends React.Component {
 				onePressed: !this.state.onePressed,
 			});
 		}
-	};
+	}
 
 	startTwo = () => {
 		if (this.props.enabledTwo) {
@@ -156,7 +156,7 @@ export default class MultiSlider extends React.Component {
 				twoPressed: !this.state.twoPressed,
 			});
 		}
-	};
+	}
 
 	moveOne = gestureState => {
 		if (!this.props.enabledOne) {
@@ -214,7 +214,7 @@ export default class MultiSlider extends React.Component {
 				);
 			}
 		}
-	};
+	}
 
 	moveTwo = gestureState => {
 		if (!this.props.enabledTwo) {
@@ -271,7 +271,7 @@ export default class MultiSlider extends React.Component {
 				);
 			}
 		}
-	};
+	}
 
 	endOne = gestureState => {
 		if (gestureState.moveX === 0 && this.props.onToggleOne) {
@@ -292,7 +292,7 @@ export default class MultiSlider extends React.Component {
 				this.props.onValuesChangeFinish(change);
 			},
 		);
-	};
+	}
 
 	endTwo = gestureState => {
 		if (gestureState.moveX === 0 && this.props.onToggleTwo) {
@@ -312,7 +312,7 @@ export default class MultiSlider extends React.Component {
 				]);
 			},
 		);
-	};
+	}
 
 	render() {
 		const { positionOne, positionTwo } = this.state;
@@ -323,7 +323,7 @@ export default class MultiSlider extends React.Component {
 			markerOffsetX,
 			markerOffsetY,
 		} = this.props;
-		const twoMarkers = this.props.values.length == 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
+		const twoMarkers = this.props.values.length === 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
 
 		const trackOneLength = positionOne;
 		const trackOneStyle = twoMarkers
@@ -365,7 +365,7 @@ export default class MultiSlider extends React.Component {
 
 		if (this.props.vertical) {
 			containerStyle.push({
-				transform: [{ rotate: '-90deg' }],
+				transform: [{ rotate: "-90deg" }],
 			});
 		}
 
@@ -480,51 +480,51 @@ export default class MultiSlider extends React.Component {
 
 const styles = StyleSheet.create({
 	container: {
-		position: 'relative',
+		position: "relative",
 		height: 50,
-		justifyContent: 'center',
+		justifyContent: "center",
 	},
 	fullTrack: {
-		flexDirection: 'row',
+		flexDirection: "row",
 	},
 	track: {
 		...Platform.select({
 			ios: {
 				height: 2,
 				borderRadius: 2,
-				backgroundColor: '#A7A7A7',
+				backgroundColor: "#A7A7A7",
 			},
 			android: {
 				height: 2,
-				backgroundColor: '#CECECE',
+				backgroundColor: "#CECECE",
 			},
 		}),
 	},
 	selectedTrack: {
 		...Platform.select({
 			ios: {
-				backgroundColor: '#095FFF',
+				backgroundColor: "#095FFF",
 			},
 			android: {
-				backgroundColor: '#0D8675',
+				backgroundColor: "#0D8675",
 			},
 		}),
 	},
 	markerContainer: {
-		position: 'absolute',
+		position: "absolute",
 		width: 48,
 		height: 48,
-		backgroundColor: 'transparent',
-		justifyContent: 'center',
-		alignItems: 'center',
+		backgroundColor: "transparent",
+		justifyContent: "center",
+		alignItems: "center",
 	},
 	topMarkerContainer: {
 		zIndex: 1,
 	},
 	touch: {
-		backgroundColor: 'transparent',
-		justifyContent: 'center',
-		alignItems: 'center',
-		alignSelf: 'stretch',
+		backgroundColor: "transparent",
+		justifyContent: "center",
+		alignItems: "center",
+		alignSelf: "stretch",
 	},
 });

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -2,16 +2,16 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import {
-	StyleSheet,
-	PanResponder,
-	View,
-	TouchableHighlight,
-	Platform,
 	I18nManager,
+	PanResponder,
+	Platform,
+	StyleSheet,
+	TouchableHighlight,
+	View,
 } from "react-native";
 
 import DefaultMarker from "./DefaultMarker";
-import { createArray, valueToPosition, positionToValue } from "./converters";
+import { createArray, positionToValue, valueToPosition } from "./converters";
 
 const ViewPropTypes = require("react-native").ViewPropTypes || View.propTypes;
 
@@ -41,6 +41,7 @@ export default class MultiSlider extends React.Component {
 		allowOverlap: false,
 		snapped: false,
 		vertical: false,
+		minMarkerOverlapDistance: 0,
 	};
 
 	constructor(props) {
@@ -175,7 +176,9 @@ export default class MultiSlider extends React.Component {
 			: accumDistance + this.state.pastOne;
 		var bottom = 0;
 		var trueTop =
-			this.state.positionTwo - (this.props.allowOverlap ? 0 : this.stepLength);
+			this.state.positionTwo - (this.props.allowOverlap ? 0 : this.props.minMarkerOverlapDistance > 0
+				? this.props.minMarkerOverlapDistance
+				: this.stepLength);
 		var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
 		var confined =
 			unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
@@ -232,7 +235,10 @@ export default class MultiSlider extends React.Component {
 			? this.state.pastTwo - accumDistance
 			: accumDistance + this.state.pastTwo;
 		var bottom =
-			this.state.positionOne + (this.props.allowOverlap ? 0 : this.stepLength);
+			this.state.positionOne + (this.props.allowOverlap ? 0
+				: this.props.minMarkerOverlapDistance > 0
+					? this.props.minMarkerOverlapDistance
+					: this.stepLength);
 		var top = this.props.sliderLength;
 		var confined =
 			unconfined < bottom ? bottom : unconfined > top ? top : unconfined;

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -40,7 +40,8 @@ export default class MultiSlider extends React.Component {
     enabledTwo: true,
     allowOverlap: false,
     snapped: false,
-    vertical: false,
+	vertical: false,
+	minMarkerOverlapDistance: 0,
   };
 
   constructor(props) {
@@ -174,8 +175,10 @@ export default class MultiSlider extends React.Component {
       ? this.state.pastOne - accumDistance
       : accumDistance + this.state.pastOne;
     var bottom = 0;
-    var trueTop =
-      this.state.positionTwo - (this.props.allowOverlap ? 0 : this.stepLength);
+	var trueTop =
+	this.state.positionTwo - (this.props.allowOverlap ? 0 : this.props.minMarkerOverlapDistance > 0
+		? this.props.minMarkerOverlapDistance
+		: this.stepLength);
     var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
     var confined =
       unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
@@ -231,8 +234,11 @@ export default class MultiSlider extends React.Component {
     const unconfined = I18nManager.isRTL
       ? this.state.pastTwo - accumDistance
       : accumDistance + this.state.pastTwo;
-    var bottom =
-      this.state.positionOne + (this.props.allowOverlap ? 0 : this.stepLength);
+	var bottom =
+	  this.state.positionOne + (this.props.allowOverlap ? 0
+		  : this.props.minMarkerOverlapDistance > 0
+			  ? this.props.minMarkerOverlapDistance
+			  : this.stepLength);
     var top = this.props.sliderLength;
     var confined =
       unconfined < bottom ? bottom : unconfined > top ? top : unconfined;

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -40,8 +40,8 @@ export default class MultiSlider extends React.Component {
     enabledTwo: true,
     allowOverlap: false,
     snapped: false,
-	vertical: false,
-	minMarkerOverlapDistance: 0,
+    vertical: false,
+    minMarkerOverlapDistance: 0,
   };
 
   constructor(props) {
@@ -103,8 +103,8 @@ export default class MultiSlider extends React.Component {
     let nextState = {};
     if (
       nextProps.min !== this.props.min ||
-	  nextProps.max !== this.props.max ||
-	  nextProps.step !== this.props.step ||
+      nextProps.max !== this.props.max ||
+      nextProps.step !== this.props.step ||
       nextProps.values[0] !== this.state.valueOne ||
       nextProps.sliderLength !== this.props.sliderLength ||
       nextProps.values[1] !== this.state.valueTwo ||
@@ -175,10 +175,10 @@ export default class MultiSlider extends React.Component {
       ? this.state.pastOne - accumDistance
       : accumDistance + this.state.pastOne;
     var bottom = 0;
-	var trueTop =
-	this.state.positionTwo - (this.props.allowOverlap ? 0 : this.props.minMarkerOverlapDistance > 0
-		? this.props.minMarkerOverlapDistance
-		: this.stepLength);
+    var trueTop =
+    this.state.positionTwo - (this.props.allowOverlap ? 0 : this.props.minMarkerOverlapDistance > 0
+        ? this.props.minMarkerOverlapDistance
+        : this.stepLength);
     var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
     var confined =
       unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
@@ -234,11 +234,11 @@ export default class MultiSlider extends React.Component {
     const unconfined = I18nManager.isRTL
       ? this.state.pastTwo - accumDistance
       : accumDistance + this.state.pastTwo;
-	var bottom =
-	  this.state.positionOne + (this.props.allowOverlap ? 0
-		  : this.props.minMarkerOverlapDistance > 0
-			  ? this.props.minMarkerOverlapDistance
-			  : this.stepLength);
+    var bottom =
+      this.state.positionOne + (this.props.allowOverlap ? 0
+          : this.props.minMarkerOverlapDistance > 0
+              ? this.props.minMarkerOverlapDistance
+              : this.stepLength);
     var top = this.props.sliderLength;
     var confined =
       unconfined < bottom ? bottom : unconfined > top ? top : unconfined;

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -2,12 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  StyleSheet,
-  PanResponder,
-  View,
-  TouchableHighlight,
-  Platform,
-  I18nManager,
+	StyleSheet,
+	PanResponder,
+	View,
+	TouchableHighlight,
+	Platform,
+	I18nManager,
 } from 'react-native';
 
 import DefaultMarker from './DefaultMarker';
@@ -16,514 +16,515 @@ import { createArray, valueToPosition, positionToValue } from './converters';
 const ViewPropTypes = require('react-native').ViewPropTypes || View.propTypes;
 
 export default class MultiSlider extends React.Component {
-  static defaultProps = {
-    values: [0],
-    onValuesChangeStart: () => {},
-    onValuesChange: values => {},
-    onValuesChangeFinish: values => {},
-    step: 1,
-    min: 0,
-    max: 10,
-    touchDimensions: {
-      borderRadius: 15,
-      slipDisplacement: 200,
-    },
-    customMarker: DefaultMarker,
-    customMarkerLeft: DefaultMarker,
-    customMarkerRight: DefaultMarker,
-    markerOffsetX: 0,
-    markerOffsetY: 0,
-    sliderLength: 280,
-    onToggleOne: undefined,
-    onToggleTwo: undefined,
-    enabledOne: true,
-    enabledTwo: true,
-    allowOverlap: false,
-    snapped: false,
-    vertical: false,
-  };
+	static defaultProps = {
+		values: [0],
+		onValuesChangeStart: () => { },
+		onValuesChange: values => { },
+		onValuesChangeFinish: values => { },
+		step: 1,
+		min: 0,
+		max: 10,
+		touchDimensions: {
+			borderRadius: 15,
+			slipDisplacement: 200,
+		},
+		customMarker: DefaultMarker,
+		customMarkerLeft: DefaultMarker,
+		customMarkerRight: DefaultMarker,
+		markerOffsetX: 0,
+		markerOffsetY: 0,
+		sliderLength: 280,
+		onToggleOne: undefined,
+		onToggleTwo: undefined,
+		enabledOne: true,
+		enabledTwo: true,
+		allowOverlap: false,
+		snapped: false,
+		vertical: false,
+	};
 
-  constructor(props) {
-    super(props);
+	constructor(props) {
+		super(props);
 
-    this.optionsArray =
-      this.props.optionsArray ||
-      createArray(this.props.min, this.props.max, this.props.step);
-    this.stepLength = this.props.sliderLength / this.optionsArray.length;
+		this.optionsArray =
+			this.props.optionsArray ||
+			createArray(this.props.min, this.props.max, this.props.step);
+		this.stepLength = this.props.sliderLength / this.optionsArray.length;
 
-    var initialValues = this.props.values.map(value =>
-      valueToPosition(value, this.optionsArray, this.props.sliderLength),
-    );
+		var initialValues = this.props.values.map(value =>
+			valueToPosition(value, this.optionsArray, this.props.sliderLength),
+		);
 
-    this.state = {
-      pressedOne: true,
-      valueOne: this.props.values[0],
-      valueTwo: this.props.values[1],
-      pastOne: initialValues[0],
-      pastTwo: initialValues[1],
-      positionOne: initialValues[0],
-      positionTwo: initialValues[1],
-    };
-  }
+		this.state = {
+			pressedOne: true,
+			valueOne: this.props.values[0],
+			valueTwo: this.props.values[1],
+			pastOne: initialValues[0],
+			pastTwo: initialValues[1],
+			positionOne: initialValues[0],
+			positionTwo: initialValues[1],
+		};
+	}
 
-  componentWillMount() {
-    var customPanResponder = (start, move, end) => {
-      return PanResponder.create({
-        onStartShouldSetPanResponder: (evt, gestureState) => true,
-        onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
-        onMoveShouldSetPanResponder: (evt, gestureState) => true,
-        onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
-        onPanResponderGrant: (evt, gestureState) => start(),
-        onPanResponderMove: (evt, gestureState) => move(gestureState),
-        onPanResponderTerminationRequest: (evt, gestureState) => false,
-        onPanResponderRelease: (evt, gestureState) => end(gestureState),
-        onPanResponderTerminate: (evt, gestureState) => end(gestureState),
-        onShouldBlockNativeResponder: (evt, gestureState) => true,
-      });
-    };
+	componentWillMount() {
+		var customPanResponder = (start, move, end) => {
+			return PanResponder.create({
+				onStartShouldSetPanResponder: (evt, gestureState) => true,
+				onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+				onMoveShouldSetPanResponder: (evt, gestureState) => true,
+				onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+				onPanResponderGrant: (evt, gestureState) => start(),
+				onPanResponderMove: (evt, gestureState) => move(gestureState),
+				onPanResponderTerminationRequest: (evt, gestureState) => false,
+				onPanResponderRelease: (evt, gestureState) => end(gestureState),
+				onPanResponderTerminate: (evt, gestureState) => end(gestureState),
+				onShouldBlockNativeResponder: (evt, gestureState) => true,
+			});
+		};
 
-    this._panResponderOne = customPanResponder(
-      this.startOne,
-      this.moveOne,
-      this.endOne,
-    );
-    this._panResponderTwo = customPanResponder(
-      this.startTwo,
-      this.moveTwo,
-      this.endTwo,
-    );
-  }
+		this._panResponderOne = customPanResponder(
+			this.startOne,
+			this.moveOne,
+			this.endOne,
+		);
+		this._panResponderTwo = customPanResponder(
+			this.startTwo,
+			this.moveTwo,
+			this.endTwo,
+		);
+	}
 
-  componentWillReceiveProps(nextProps) {
-    if (this.state.onePressed || this.state.twoPressed) {
-      return;
-    }
+	componentWillReceiveProps(nextProps) {
+		if (this.state.onePressed || this.state.twoPressed) {
+			return;
+		}
 
-    let nextState = {};
-    if (
-      nextProps.min !== this.props.min ||
-      nextProps.max !== this.props.max ||
-      nextProps.values[0] !== this.state.valueOne ||
-      nextProps.sliderLength !== this.props.sliderLength ||
-      nextProps.values[1] !== this.state.valueTwo ||
-      (nextProps.sliderLength !== this.props.sliderLength &&
-        nextProps.values[1])
-    ) {
-      this.optionsArray =
-        this.props.optionsArray ||
-        createArray(nextProps.min, nextProps.max, nextProps.step);
+		let nextState = {};
+		if (
+			nextProps.min !== this.props.min ||
+			nextProps.max !== this.props.max ||
+			nextProps.step !== this.props.step ||
+			nextProps.values[0] !== this.state.valueOne ||
+			nextProps.sliderLength !== this.props.sliderLength ||
+			nextProps.values[1] !== this.state.valueTwo ||
+			(nextProps.sliderLength !== this.props.sliderLength &&
+				nextProps.values[1])
+		) {
+			this.optionsArray =
+				this.props.optionsArray ||
+				createArray(nextProps.min, nextProps.max, nextProps.step);
 
-      this.stepLength = this.props.sliderLength / this.optionsArray.length;
+			this.stepLength = this.props.sliderLength / this.optionsArray.length;
 
-      var positionOne = valueToPosition(
-        nextProps.values[0],
-        this.optionsArray,
-        nextProps.sliderLength,
-      );
-      nextState.valueOne = nextProps.values[0];
-      nextState.pastOne = positionOne;
-      nextState.positionOne = positionOne;
+			var positionOne = valueToPosition(
+				nextProps.values[0],
+				this.optionsArray,
+				nextProps.sliderLength,
+			);
+			nextState.valueOne = nextProps.values[0];
+			nextState.pastOne = positionOne;
+			nextState.positionOne = positionOne;
 
-      var positionTwo = valueToPosition(
-        nextProps.values[1],
-        this.optionsArray,
-        nextProps.sliderLength,
-      );
-      nextState.valueTwo = nextProps.values[1];
-      nextState.pastTwo = positionTwo;
-      nextState.positionTwo = positionTwo;
-    }
+			var positionTwo = valueToPosition(
+				nextProps.values[1],
+				this.optionsArray,
+				nextProps.sliderLength,
+			);
+			nextState.valueTwo = nextProps.values[1];
+			nextState.pastTwo = positionTwo;
+			nextState.positionTwo = positionTwo;
+		}
 
-    if (nextState != {}) {
-      this.setState(nextState);
-    }
-  }
+		if (nextState != {}) {
+			this.setState(nextState);
+		}
+	}
 
-  startOne = () => {
-    if (this.props.enabledOne) {
-      this.props.onValuesChangeStart();
-      this.setState({
-        onePressed: !this.state.onePressed,
-      });
-    }
-  };
+	startOne = () => {
+		if (this.props.enabledOne) {
+			this.props.onValuesChangeStart();
+			this.setState({
+				onePressed: !this.state.onePressed,
+			});
+		}
+	};
 
-  startTwo = () => {
-    if (this.props.enabledTwo) {
-      this.props.onValuesChangeStart();
-      this.setState({
-        twoPressed: !this.state.twoPressed,
-      });
-    }
-  };
+	startTwo = () => {
+		if (this.props.enabledTwo) {
+			this.props.onValuesChangeStart();
+			this.setState({
+				twoPressed: !this.state.twoPressed,
+			});
+		}
+	};
 
-  moveOne = gestureState => {
-    if (!this.props.enabledOne) {
-      return;
-    }
+	moveOne = gestureState => {
+		if (!this.props.enabledOne) {
+			return;
+		}
 
-    const accumDistance = this.props.vertical
-      ? -gestureState.dy
-      : gestureState.dx;
-    const accumDistanceDisplacement = this.props.vertical
-      ? gestureState.dx
-      : gestureState.dy;
+		const accumDistance = this.props.vertical
+			? -gestureState.dy
+			: gestureState.dx;
+		const accumDistanceDisplacement = this.props.vertical
+			? gestureState.dx
+			: gestureState.dy;
 
-    const unconfined = I18nManager.isRTL
-      ? this.state.pastOne - accumDistance
-      : accumDistance + this.state.pastOne;
-    var bottom = 0;
-    var trueTop =
-      this.state.positionTwo - (this.props.allowOverlap ? 0 : this.stepLength);
-    var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
-    var confined =
-      unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
-    var slipDisplacement = this.props.touchDimensions.slipDisplacement;
+		const unconfined = I18nManager.isRTL
+			? this.state.pastOne - accumDistance
+			: accumDistance + this.state.pastOne;
+		var bottom = 0;
+		var trueTop =
+			this.state.positionTwo - (this.props.allowOverlap ? 0 : this.stepLength);
+		var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
+		var confined =
+			unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
+		var slipDisplacement = this.props.touchDimensions.slipDisplacement;
 
-    if (
-      Math.abs(accumDistanceDisplacement) < slipDisplacement ||
-      !slipDisplacement
-    ) {
-      var value = positionToValue(
-        confined,
-        this.optionsArray,
-        this.props.sliderLength,
-      );
-      var snapped = valueToPosition(
-        value,
-        this.optionsArray,
-        this.props.sliderLength,
-      );
-      this.setState({
-        positionOne: this.props.snapped ? snapped : confined,
-      });
+		if (
+			Math.abs(accumDistanceDisplacement) < slipDisplacement ||
+			!slipDisplacement
+		) {
+			var value = positionToValue(
+				confined,
+				this.optionsArray,
+				this.props.sliderLength,
+			);
+			var snapped = valueToPosition(
+				value,
+				this.optionsArray,
+				this.props.sliderLength,
+			);
+			this.setState({
+				positionOne: this.props.snapped ? snapped : confined,
+			});
 
-      if (value !== this.state.valueOne) {
-        this.setState(
-          {
-            valueOne: value,
-          },
-          () => {
-            var change = [this.state.valueOne];
-            if (this.state.valueTwo) {
-              change.push(this.state.valueTwo);
-            }
-            this.props.onValuesChange(change);
-          },
-        );
-      }
-    }
-  };
+			if (value !== this.state.valueOne) {
+				this.setState(
+					{
+						valueOne: value,
+					},
+					() => {
+						var change = [this.state.valueOne];
+						if (this.state.valueTwo) {
+							change.push(this.state.valueTwo);
+						}
+						this.props.onValuesChange(change);
+					},
+				);
+			}
+		}
+	};
 
-  moveTwo = gestureState => {
-    if (!this.props.enabledTwo) {
-      return;
-    }
+	moveTwo = gestureState => {
+		if (!this.props.enabledTwo) {
+			return;
+		}
 
-    const accumDistance = this.props.vertical
-      ? -gestureState.dy
-      : gestureState.dx;
-    const accumDistanceDisplacement = this.props.vertical
-      ? gestureState.dx
-      : gestureState.dy;
+		const accumDistance = this.props.vertical
+			? -gestureState.dy
+			: gestureState.dx;
+		const accumDistanceDisplacement = this.props.vertical
+			? gestureState.dx
+			: gestureState.dy;
 
-    const unconfined = I18nManager.isRTL
-      ? this.state.pastTwo - accumDistance
-      : accumDistance + this.state.pastTwo;
-    var bottom =
-      this.state.positionOne + (this.props.allowOverlap ? 0 : this.stepLength);
-    var top = this.props.sliderLength;
-    var confined =
-      unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
-    var slipDisplacement = this.props.touchDimensions.slipDisplacement;
+		const unconfined = I18nManager.isRTL
+			? this.state.pastTwo - accumDistance
+			: accumDistance + this.state.pastTwo;
+		var bottom =
+			this.state.positionOne + (this.props.allowOverlap ? 0 : this.stepLength);
+		var top = this.props.sliderLength;
+		var confined =
+			unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
+		var slipDisplacement = this.props.touchDimensions.slipDisplacement;
 
-    if (
-      Math.abs(accumDistanceDisplacement) < slipDisplacement ||
-      !slipDisplacement
-    ) {
-      var value = positionToValue(
-        confined,
-        this.optionsArray,
-        this.props.sliderLength,
-      );
-      var snapped = valueToPosition(
-        value,
-        this.optionsArray,
-        this.props.sliderLength,
-      );
+		if (
+			Math.abs(accumDistanceDisplacement) < slipDisplacement ||
+			!slipDisplacement
+		) {
+			var value = positionToValue(
+				confined,
+				this.optionsArray,
+				this.props.sliderLength,
+			);
+			var snapped = valueToPosition(
+				value,
+				this.optionsArray,
+				this.props.sliderLength,
+			);
 
-      this.setState({
-        positionTwo: this.props.snapped ? snapped : confined,
-      });
+			this.setState({
+				positionTwo: this.props.snapped ? snapped : confined,
+			});
 
-      if (value !== this.state.valueTwo) {
-        this.setState(
-          {
-            valueTwo: value,
-          },
-          () => {
-            this.props.onValuesChange([
-              this.state.valueOne,
-              this.state.valueTwo,
-            ]);
-          },
-        );
-      }
-    }
-  };
+			if (value !== this.state.valueTwo) {
+				this.setState(
+					{
+						valueTwo: value,
+					},
+					() => {
+						this.props.onValuesChange([
+							this.state.valueOne,
+							this.state.valueTwo,
+						]);
+					},
+				);
+			}
+		}
+	};
 
-  endOne = gestureState => {
-    if (gestureState.moveX === 0 && this.props.onToggleOne) {
-      this.props.onToggleOne();
-      return;
-    }
+	endOne = gestureState => {
+		if (gestureState.moveX === 0 && this.props.onToggleOne) {
+			this.props.onToggleOne();
+			return;
+		}
 
-    this.setState(
-      {
-        pastOne: this.state.positionOne,
-        onePressed: !this.state.onePressed,
-      },
-      () => {
-        var change = [this.state.valueOne];
-        if (this.state.valueTwo) {
-          change.push(this.state.valueTwo);
-        }
-        this.props.onValuesChangeFinish(change);
-      },
-    );
-  };
+		this.setState(
+			{
+				pastOne: this.state.positionOne,
+				onePressed: !this.state.onePressed,
+			},
+			() => {
+				var change = [this.state.valueOne];
+				if (this.state.valueTwo) {
+					change.push(this.state.valueTwo);
+				}
+				this.props.onValuesChangeFinish(change);
+			},
+		);
+	};
 
-  endTwo = gestureState => {
-    if (gestureState.moveX === 0 && this.props.onToggleTwo) {
-      this.props.onToggleTwo();
-      return;
-    }
+	endTwo = gestureState => {
+		if (gestureState.moveX === 0 && this.props.onToggleTwo) {
+			this.props.onToggleTwo();
+			return;
+		}
 
-    this.setState(
-      {
-        twoPressed: !this.state.twoPressed,
-        pastTwo: this.state.positionTwo,
-      },
-      () => {
-        this.props.onValuesChangeFinish([
-          this.state.valueOne,
-          this.state.valueTwo,
-        ]);
-      },
-    );
-  };
+		this.setState(
+			{
+				twoPressed: !this.state.twoPressed,
+				pastTwo: this.state.positionTwo,
+			},
+			() => {
+				this.props.onValuesChangeFinish([
+					this.state.valueOne,
+					this.state.valueTwo,
+				]);
+			},
+		);
+	};
 
-  render() {
-    const { positionOne, positionTwo } = this.state;
-    const {
-      selectedStyle,
-      unselectedStyle,
-      sliderLength,
-      markerOffsetX,
-      markerOffsetY,
-    } = this.props;
-    const twoMarkers = this.props.values.length == 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
+	render() {
+		const { positionOne, positionTwo } = this.state;
+		const {
+			selectedStyle,
+			unselectedStyle,
+			sliderLength,
+			markerOffsetX,
+			markerOffsetY,
+		} = this.props;
+		const twoMarkers = this.props.values.length == 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
 
-    const trackOneLength = positionOne;
-    const trackOneStyle = twoMarkers
-      ? unselectedStyle
-      : selectedStyle || styles.selectedTrack;
-    const trackThreeLength = twoMarkers ? sliderLength - positionTwo : 0;
-    const trackThreeStyle = unselectedStyle;
-    const trackTwoLength = sliderLength - trackOneLength - trackThreeLength;
-    const trackTwoStyle = twoMarkers
-      ? selectedStyle || styles.selectedTrack
-      : unselectedStyle;
-    const Marker = this.props.customMarker;
+		const trackOneLength = positionOne;
+		const trackOneStyle = twoMarkers
+			? unselectedStyle
+			: selectedStyle || styles.selectedTrack;
+		const trackThreeLength = twoMarkers ? sliderLength - positionTwo : 0;
+		const trackThreeStyle = unselectedStyle;
+		const trackTwoLength = sliderLength - trackOneLength - trackThreeLength;
+		const trackTwoStyle = twoMarkers
+			? selectedStyle || styles.selectedTrack
+			: unselectedStyle;
+		const Marker = this.props.customMarker;
 
-    const MarkerLeft = this.props.customMarkerLeft;
-    const MarkerRight = this.props.customMarkerRight;
-    const isMarkersSeparated = this.props.isMarkersSeparated || false;
+		const MarkerLeft = this.props.customMarkerLeft;
+		const MarkerRight = this.props.customMarkerRight;
+		const isMarkersSeparated = this.props.isMarkersSeparated || false;
 
-    const {
-      slipDisplacement,
-      height,
-      width,
-      borderRadius,
-    } = this.props.touchDimensions;
-    const touchStyle = {
-      borderRadius: borderRadius || 0,
-    };
+		const {
+			slipDisplacement,
+			height,
+			width,
+			borderRadius,
+		} = this.props.touchDimensions;
+		const touchStyle = {
+			borderRadius: borderRadius || 0,
+		};
 
-    const markerContainerOne = {
-      top: markerOffsetY - 24,
-      left: trackOneLength + markerOffsetX - 24,
-    };
+		const markerContainerOne = {
+			top: markerOffsetY - 24,
+			left: trackOneLength + markerOffsetX - 24,
+		};
 
-    const markerContainerTwo = {
-      top: markerOffsetY - 24,
-      right: trackThreeLength + markerOffsetX - 24,
-    };
+		const markerContainerTwo = {
+			top: markerOffsetY - 24,
+			right: trackThreeLength + markerOffsetX - 24,
+		};
 
-    const containerStyle = [styles.container, this.props.containerStyle];
+		const containerStyle = [styles.container, this.props.containerStyle];
 
-    if (this.props.vertical) {
-      containerStyle.push({
-        transform: [{ rotate: '-90deg' }],
-      });
-    }
+		if (this.props.vertical) {
+			containerStyle.push({
+				transform: [{ rotate: '-90deg' }],
+			});
+		}
 
-    return (
-      <View style={containerStyle}>
-        <View style={[styles.fullTrack, { width: sliderLength }]}>
-          <View
-            style={[
-              styles.track,
-              this.props.trackStyle,
-              trackOneStyle,
-              { width: trackOneLength },
-            ]}
-          />
-          <View
-            style={[
-              styles.track,
-              this.props.trackStyle,
-              trackTwoStyle,
-              { width: trackTwoLength },
-            ]}
-          />
-          {twoMarkers && (
-            <View
-              style={[
-                styles.track,
-                this.props.trackStyle,
-                trackThreeStyle,
-                { width: trackThreeLength },
-              ]}
-            />
-          )}
-          <View
-            style={[
-              styles.markerContainer,
-              markerContainerOne,
-              this.props.markerContainerStyle,
-              positionOne > sliderLength / 2 && styles.topMarkerContainer,
-            ]}
-          >
-            <View
-              style={[styles.touch, touchStyle]}
-              ref={component => (this._markerOne = component)}
-              {...this._panResponderOne.panHandlers}
-            >
-              {isMarkersSeparated === false ? (
-                <Marker
-                  enabled={this.props.enabledOne}
-                  pressed={this.state.onePressed}
-                  markerStyle={[styles.marker, this.props.markerStyle]}
-                  pressedMarkerStyle={this.props.pressedMarkerStyle}
-                  currentValue={this.state.valueOne}
-                  valuePrefix={this.props.valuePrefix}
-                  valueSuffix={this.props.valueSuffix}
-                />
-              ) : (
-                <MarkerLeft
-                  enabled={this.props.enabledOne}
-                  pressed={this.state.onePressed}
-                  markerStyle={[styles.marker, this.props.markerStyle]}
-                  pressedMarkerStyle={this.props.pressedMarkerStyle}
-                  currentValue={this.state.valueOne}
-                  valuePrefix={this.props.valuePrefix}
-                  valueSuffix={this.props.valueSuffix}
-                />
-              )}
-            </View>
-          </View>
-          {twoMarkers &&
-            positionOne !== this.props.sliderLength && (
-              <View
-                style={[
-                  styles.markerContainer,
-                  markerContainerTwo,
-                  this.props.markerContainerStyle,
-                ]}
-              >
-                <View
-                  style={[styles.touch, touchStyle]}
-                  ref={component => (this._markerTwo = component)}
-                  {...this._panResponderTwo.panHandlers}
-                >
-                  {isMarkersSeparated === false ? (
-                    <Marker
-                      pressed={this.state.twoPressed}
-                      markerStyle={this.props.markerStyle}
-                      pressedMarkerStyle={this.props.pressedMarkerStyle}
-                      currentValue={this.state.valueTwo}
-                      enabled={this.props.enabledTwo}
-                      valuePrefix={this.props.valuePrefix}
-                      valueSuffix={this.props.valueSuffix}
-                    />
-                  ) : (
-                    <MarkerRight
-                      pressed={this.state.twoPressed}
-                      markerStyle={this.props.markerStyle}
-                      pressedMarkerStyle={this.props.pressedMarkerStyle}
-                      currentValue={this.state.valueTwo}
-                      enabled={this.props.enabledTwo}
-                      valuePrefix={this.props.valuePrefix}
-                      valueSuffix={this.props.valueSuffix}
-                    />
-                  )}
-                </View>
-              </View>
-            )}
-        </View>
-      </View>
-    );
-  }
+		return (
+			<View style={containerStyle}>
+				<View style={[styles.fullTrack, { width: sliderLength }]}>
+					<View
+						style={[
+							styles.track,
+							this.props.trackStyle,
+							trackOneStyle,
+							{ width: trackOneLength },
+						]}
+					/>
+					<View
+						style={[
+							styles.track,
+							this.props.trackStyle,
+							trackTwoStyle,
+							{ width: trackTwoLength },
+						]}
+					/>
+					{twoMarkers && (
+						<View
+							style={[
+								styles.track,
+								this.props.trackStyle,
+								trackThreeStyle,
+								{ width: trackThreeLength },
+							]}
+						/>
+					)}
+					<View
+						style={[
+							styles.markerContainer,
+							markerContainerOne,
+							this.props.markerContainerStyle,
+							positionOne > sliderLength / 2 && styles.topMarkerContainer,
+						]}
+					>
+						<View
+							style={[styles.touch, touchStyle]}
+							ref={component => (this._markerOne = component)}
+							{...this._panResponderOne.panHandlers}
+						>
+							{isMarkersSeparated === false ? (
+								<Marker
+									enabled={this.props.enabledOne}
+									pressed={this.state.onePressed}
+									markerStyle={[styles.marker, this.props.markerStyle]}
+									pressedMarkerStyle={this.props.pressedMarkerStyle}
+									currentValue={this.state.valueOne}
+									valuePrefix={this.props.valuePrefix}
+									valueSuffix={this.props.valueSuffix}
+								/>
+							) : (
+									<MarkerLeft
+										enabled={this.props.enabledOne}
+										pressed={this.state.onePressed}
+										markerStyle={[styles.marker, this.props.markerStyle]}
+										pressedMarkerStyle={this.props.pressedMarkerStyle}
+										currentValue={this.state.valueOne}
+										valuePrefix={this.props.valuePrefix}
+										valueSuffix={this.props.valueSuffix}
+									/>
+								)}
+						</View>
+					</View>
+					{twoMarkers &&
+						positionOne !== this.props.sliderLength && (
+							<View
+								style={[
+									styles.markerContainer,
+									markerContainerTwo,
+									this.props.markerContainerStyle,
+								]}
+							>
+								<View
+									style={[styles.touch, touchStyle]}
+									ref={component => (this._markerTwo = component)}
+									{...this._panResponderTwo.panHandlers}
+								>
+									{isMarkersSeparated === false ? (
+										<Marker
+											pressed={this.state.twoPressed}
+											markerStyle={this.props.markerStyle}
+											pressedMarkerStyle={this.props.pressedMarkerStyle}
+											currentValue={this.state.valueTwo}
+											enabled={this.props.enabledTwo}
+											valuePrefix={this.props.valuePrefix}
+											valueSuffix={this.props.valueSuffix}
+										/>
+									) : (
+											<MarkerRight
+												pressed={this.state.twoPressed}
+												markerStyle={this.props.markerStyle}
+												pressedMarkerStyle={this.props.pressedMarkerStyle}
+												currentValue={this.state.valueTwo}
+												enabled={this.props.enabledTwo}
+												valuePrefix={this.props.valuePrefix}
+												valueSuffix={this.props.valueSuffix}
+											/>
+										)}
+								</View>
+							</View>
+						)}
+				</View>
+			</View>
+		);
+	}
 }
 
 const styles = StyleSheet.create({
-  container: {
-    position: 'relative',
-    height: 50,
-    justifyContent: 'center',
-  },
-  fullTrack: {
-    flexDirection: 'row',
-  },
-  track: {
-    ...Platform.select({
-      ios: {
-        height: 2,
-        borderRadius: 2,
-        backgroundColor: '#A7A7A7',
-      },
-      android: {
-        height: 2,
-        backgroundColor: '#CECECE',
-      },
-    }),
-  },
-  selectedTrack: {
-    ...Platform.select({
-      ios: {
-        backgroundColor: '#095FFF',
-      },
-      android: {
-        backgroundColor: '#0D8675',
-      },
-    }),
-  },
-  markerContainer: {
-    position: 'absolute',
-    width: 48,
-    height: 48,
-    backgroundColor: 'transparent',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  topMarkerContainer: {
-    zIndex: 1,
-  },
-  touch: {
-    backgroundColor: 'transparent',
-    justifyContent: 'center',
-    alignItems: 'center',
-    alignSelf: 'stretch',
-  },
+	container: {
+		position: 'relative',
+		height: 50,
+		justifyContent: 'center',
+	},
+	fullTrack: {
+		flexDirection: 'row',
+	},
+	track: {
+		...Platform.select({
+			ios: {
+				height: 2,
+				borderRadius: 2,
+				backgroundColor: '#A7A7A7',
+			},
+			android: {
+				height: 2,
+				backgroundColor: '#CECECE',
+			},
+		}),
+	},
+	selectedTrack: {
+		...Platform.select({
+			ios: {
+				backgroundColor: '#095FFF',
+			},
+			android: {
+				backgroundColor: '#0D8675',
+			},
+		}),
+	},
+	markerContainer: {
+		position: 'absolute',
+		width: 48,
+		height: 48,
+		backgroundColor: 'transparent',
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	topMarkerContainer: {
+		zIndex: 1,
+	},
+	touch: {
+		backgroundColor: 'transparent',
+		justifyContent: 'center',
+		alignItems: 'center',
+		alignSelf: 'stretch',
+	},
 });

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -176,9 +176,9 @@ export default class MultiSlider extends React.Component {
       : accumDistance + this.state.pastOne;
     var bottom = 0;
     var trueTop =
-    this.state.positionTwo - (this.props.allowOverlap ? 0 : this.props.minMarkerOverlapDistance > 0
-        ? this.props.minMarkerOverlapDistance
-        : this.stepLength);
+        this.state.positionTwo - (this.props.allowOverlap ? 0 : this.props.minMarkerOverlapDistance > 0
+            ? this.props.minMarkerOverlapDistance
+            : this.stepLength);
     var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
     var confined =
       unconfined < bottom ? bottom : unconfined > top ? top : unconfined;

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-	I18nManager,
-	PanResponder,
-	Platform,
-	I18nManager,
+  StyleSheet,
+  PanResponder,
+  View,
+  TouchableHighlight,
+  Platform,
+  I18nManager,
 } from 'react-native';
 
 import DefaultMarker from './DefaultMarker';
@@ -14,521 +16,514 @@ import { createArray, valueToPosition, positionToValue } from './converters';
 const ViewPropTypes = require('react-native').ViewPropTypes || View.propTypes;
 
 export default class MultiSlider extends React.Component {
-	static defaultProps = {
-		values: [0],
-		onValuesChangeStart: () => { },
-		onValuesChange: values => { },
-		onValuesChangeFinish: values => { },
-		step: 1,
-		min: 0,
-		max: 10,
-		touchDimensions: {
-			borderRadius: 15,
-			slipDisplacement: 200,
-		},
-		customMarker: DefaultMarker,
-		customMarkerLeft: DefaultMarker,
-		customMarkerRight: DefaultMarker,
-		markerOffsetX: 0,
-		markerOffsetY: 0,
-		sliderLength: 280,
-		onToggleOne: undefined,
-		onToggleTwo: undefined,
-		enabledOne: true,
-		enabledTwo: true,
-		allowOverlap: false,
-		snapped: false,
-		vertical: false,
-		minMarkerOverlapDistance: 0,
-	};
+  static defaultProps = {
+    values: [0],
+    onValuesChangeStart: () => {},
+    onValuesChange: values => {},
+    onValuesChangeFinish: values => {},
+    step: 1,
+    min: 0,
+    max: 10,
+    touchDimensions: {
+      borderRadius: 15,
+      slipDisplacement: 200,
+    },
+    customMarker: DefaultMarker,
+    customMarkerLeft: DefaultMarker,
+    customMarkerRight: DefaultMarker,
+    markerOffsetX: 0,
+    markerOffsetY: 0,
+    sliderLength: 280,
+    onToggleOne: undefined,
+    onToggleTwo: undefined,
+    enabledOne: true,
+    enabledTwo: true,
+    allowOverlap: false,
+    snapped: false,
+    vertical: false,
+  };
 
-	constructor(props) {
-		super(props);
+  constructor(props) {
+    super(props);
 
-		this.optionsArray =
-			this.props.optionsArray ||
-			createArray(this.props.min, this.props.max, this.props.step);
-		this.stepLength = this.props.sliderLength / this.optionsArray.length;
+    this.optionsArray =
+      this.props.optionsArray ||
+      createArray(this.props.min, this.props.max, this.props.step);
+    this.stepLength = this.props.sliderLength / this.optionsArray.length;
 
-		var initialValues = this.props.values.map(value =>
-			valueToPosition(value, this.optionsArray, this.props.sliderLength),
-		);
+    var initialValues = this.props.values.map(value =>
+      valueToPosition(value, this.optionsArray, this.props.sliderLength),
+    );
 
-		this.state = {
-			pressedOne: true,
-			valueOne: this.props.values[0],
-			valueTwo: this.props.values[1],
-			pastOne: initialValues[0],
-			pastTwo: initialValues[1],
-			positionOne: initialValues[0],
-			positionTwo: initialValues[1],
-		};
-	}
+    this.state = {
+      pressedOne: true,
+      valueOne: this.props.values[0],
+      valueTwo: this.props.values[1],
+      pastOne: initialValues[0],
+      pastTwo: initialValues[1],
+      positionOne: initialValues[0],
+      positionTwo: initialValues[1],
+    };
+  }
 
-	componentWillMount() {
-		var customPanResponder = (start, move, end) => {
-			return PanResponder.create({
-				onStartShouldSetPanResponder: (evt, gestureState) => true,
-				onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
-				onMoveShouldSetPanResponder: (evt, gestureState) => true,
-				onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
-				onPanResponderGrant: (evt, gestureState) => start(),
-				onPanResponderMove: (evt, gestureState) => move(gestureState),
-				onPanResponderTerminationRequest: (evt, gestureState) => false,
-				onPanResponderRelease: (evt, gestureState) => end(gestureState),
-				onPanResponderTerminate: (evt, gestureState) => end(gestureState),
-				onShouldBlockNativeResponder: (evt, gestureState) => true,
-			});
-		};
+  componentWillMount() {
+    var customPanResponder = (start, move, end) => {
+      return PanResponder.create({
+        onStartShouldSetPanResponder: (evt, gestureState) => true,
+        onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
+        onMoveShouldSetPanResponder: (evt, gestureState) => true,
+        onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
+        onPanResponderGrant: (evt, gestureState) => start(),
+        onPanResponderMove: (evt, gestureState) => move(gestureState),
+        onPanResponderTerminationRequest: (evt, gestureState) => false,
+        onPanResponderRelease: (evt, gestureState) => end(gestureState),
+        onPanResponderTerminate: (evt, gestureState) => end(gestureState),
+        onShouldBlockNativeResponder: (evt, gestureState) => true,
+      });
+    };
 
-		this._panResponderOne = customPanResponder(
-			this.startOne,
-			this.moveOne,
-			this.endOne,
-		);
-		this._panResponderTwo = customPanResponder(
-			this.startTwo,
-			this.moveTwo,
-			this.endTwo,
-		);
-	}
+    this._panResponderOne = customPanResponder(
+      this.startOne,
+      this.moveOne,
+      this.endOne,
+    );
+    this._panResponderTwo = customPanResponder(
+      this.startTwo,
+      this.moveTwo,
+      this.endTwo,
+    );
+  }
 
-	componentWillReceiveProps(nextProps) {
-		if (this.state.onePressed || this.state.twoPressed) {
-			return;
-		}
+  componentWillReceiveProps(nextProps) {
+    if (this.state.onePressed || this.state.twoPressed) {
+      return;
+    }
 
-		let nextState = {};
-		if (
-			nextProps.min !== this.props.min ||
-			nextProps.max !== this.props.max ||
-			nextProps.step !== this.props.step ||
-			nextProps.values[0] !== this.state.valueOne ||
-			nextProps.sliderLength !== this.props.sliderLength ||
-			nextProps.values[1] !== this.state.valueTwo ||
-			(nextProps.sliderLength !== this.props.sliderLength &&
-				nextProps.values[1])
-		) {
-			this.optionsArray =
-				this.props.optionsArray ||
-				createArray(nextProps.min, nextProps.max, nextProps.step);
+    let nextState = {};
+    if (
+      nextProps.min !== this.props.min ||
+      nextProps.max !== this.props.max ||
+      nextProps.values[0] !== this.state.valueOne ||
+      nextProps.sliderLength !== this.props.sliderLength ||
+      nextProps.values[1] !== this.state.valueTwo ||
+      (nextProps.sliderLength !== this.props.sliderLength &&
+        nextProps.values[1])
+    ) {
+      this.optionsArray =
+        this.props.optionsArray ||
+        createArray(nextProps.min, nextProps.max, nextProps.step);
 
-			this.stepLength = this.props.sliderLength / this.optionsArray.length;
+      this.stepLength = this.props.sliderLength / this.optionsArray.length;
 
-			var positionOne = valueToPosition(
-				nextProps.values[0],
-				this.optionsArray,
-				nextProps.sliderLength,
-			);
-			nextState.valueOne = nextProps.values[0];
-			nextState.pastOne = positionOne;
-			nextState.positionOne = positionOne;
+      var positionOne = valueToPosition(
+        nextProps.values[0],
+        this.optionsArray,
+        nextProps.sliderLength,
+      );
+      nextState.valueOne = nextProps.values[0];
+      nextState.pastOne = positionOne;
+      nextState.positionOne = positionOne;
 
-			var positionTwo = valueToPosition(
-				nextProps.values[1],
-				this.optionsArray,
-				nextProps.sliderLength,
-			);
-			nextState.valueTwo = nextProps.values[1];
-			nextState.pastTwo = positionTwo;
-			nextState.positionTwo = positionTwo;
-		}
+      var positionTwo = valueToPosition(
+        nextProps.values[1],
+        this.optionsArray,
+        nextProps.sliderLength,
+      );
+      nextState.valueTwo = nextProps.values[1];
+      nextState.pastTwo = positionTwo;
+      nextState.positionTwo = positionTwo;
+    }
 
-		if (nextState != {}) {
-			this.setState(nextState);
-		}
-	}
+    if (nextState != {}) {
+      this.setState(nextState);
+    }
+  }
 
-	startOne = () => {
-		if (this.props.enabledOne) {
-			this.props.onValuesChangeStart();
-			this.setState({
-				onePressed: !this.state.onePressed,
-			});
-		}
-	};
+  startOne = () => {
+    if (this.props.enabledOne) {
+      this.props.onValuesChangeStart();
+      this.setState({
+        onePressed: !this.state.onePressed,
+      });
+    }
+  };
 
-	startTwo = () => {
-		if (this.props.enabledTwo) {
-			this.props.onValuesChangeStart();
-			this.setState({
-				twoPressed: !this.state.twoPressed,
-			});
-		}
-	};
+  startTwo = () => {
+    if (this.props.enabledTwo) {
+      this.props.onValuesChangeStart();
+      this.setState({
+        twoPressed: !this.state.twoPressed,
+      });
+    }
+  };
 
-	moveOne = gestureState => {
-		if (!this.props.enabledOne) {
-			return;
-		}
+  moveOne = gestureState => {
+    if (!this.props.enabledOne) {
+      return;
+    }
 
-		const accumDistance = this.props.vertical
-			? -gestureState.dy
-			: gestureState.dx;
-		const accumDistanceDisplacement = this.props.vertical
-			? gestureState.dx
-			: gestureState.dy;
+    const accumDistance = this.props.vertical
+      ? -gestureState.dy
+      : gestureState.dx;
+    const accumDistanceDisplacement = this.props.vertical
+      ? gestureState.dx
+      : gestureState.dy;
 
-		const unconfined = I18nManager.isRTL
-			? this.state.pastOne - accumDistance
-			: accumDistance + this.state.pastOne;
-		var bottom = 0;
-		var trueTop =
-			this.state.positionTwo - (this.props.allowOverlap ? 0 : this.props.minMarkerOverlapDistance > 0
-				? this.props.minMarkerOverlapDistance
-				: this.stepLength);
-		var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
-		var confined =
-			unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
-		var slipDisplacement = this.props.touchDimensions.slipDisplacement;
+    const unconfined = I18nManager.isRTL
+      ? this.state.pastOne - accumDistance
+      : accumDistance + this.state.pastOne;
+    var bottom = 0;
+    var trueTop =
+      this.state.positionTwo - (this.props.allowOverlap ? 0 : this.stepLength);
+    var top = trueTop === 0 ? 0 : trueTop || this.props.sliderLength;
+    var confined =
+      unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
+    var slipDisplacement = this.props.touchDimensions.slipDisplacement;
 
-		if (
-			Math.abs(accumDistanceDisplacement) < slipDisplacement ||
-			!slipDisplacement
-		) {
-			var value = positionToValue(
-				confined,
-				this.optionsArray,
-				this.props.sliderLength,
-			);
-			var snapped = valueToPosition(
-				value,
-				this.optionsArray,
-				this.props.sliderLength,
-			);
-			this.setState({
-				positionOne: this.props.snapped ? snapped : confined,
-			});
+    if (
+      Math.abs(accumDistanceDisplacement) < slipDisplacement ||
+      !slipDisplacement
+    ) {
+      var value = positionToValue(
+        confined,
+        this.optionsArray,
+        this.props.sliderLength,
+      );
+      var snapped = valueToPosition(
+        value,
+        this.optionsArray,
+        this.props.sliderLength,
+      );
+      this.setState({
+        positionOne: this.props.snapped ? snapped : confined,
+      });
 
-			if (value !== this.state.valueOne) {
-				this.setState(
-					{
-						valueOne: value,
-					},
-					() => {
-						var change = [this.state.valueOne];
-						if (this.state.valueTwo) {
-							change.push(this.state.valueTwo);
-						}
-						this.props.onValuesChange(change);
-					},
-				);
-			}
-		}
-	};
+      if (value !== this.state.valueOne) {
+        this.setState(
+          {
+            valueOne: value,
+          },
+          () => {
+            var change = [this.state.valueOne];
+            if (this.state.valueTwo) {
+              change.push(this.state.valueTwo);
+            }
+            this.props.onValuesChange(change);
+          },
+        );
+      }
+    }
+  };
 
-	moveTwo = gestureState => {
-		if (!this.props.enabledTwo) {
-			return;
-		}
+  moveTwo = gestureState => {
+    if (!this.props.enabledTwo) {
+      return;
+    }
 
-		const accumDistance = this.props.vertical
-			? -gestureState.dy
-			: gestureState.dx;
-		const accumDistanceDisplacement = this.props.vertical
-			? gestureState.dx
-			: gestureState.dy;
+    const accumDistance = this.props.vertical
+      ? -gestureState.dy
+      : gestureState.dx;
+    const accumDistanceDisplacement = this.props.vertical
+      ? gestureState.dx
+      : gestureState.dy;
 
-		const unconfined = I18nManager.isRTL
-			? this.state.pastTwo - accumDistance
-			: accumDistance + this.state.pastTwo;
-		var bottom =
-			this.state.positionOne + (this.props.allowOverlap ? 0
-				: this.props.minMarkerOverlapDistance > 0
-					? this.props.minMarkerOverlapDistance
-					: this.stepLength);
-		var top = this.props.sliderLength;
-		var confined =
-			unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
-		var slipDisplacement = this.props.touchDimensions.slipDisplacement;
+    const unconfined = I18nManager.isRTL
+      ? this.state.pastTwo - accumDistance
+      : accumDistance + this.state.pastTwo;
+    var bottom =
+      this.state.positionOne + (this.props.allowOverlap ? 0 : this.stepLength);
+    var top = this.props.sliderLength;
+    var confined =
+      unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
+    var slipDisplacement = this.props.touchDimensions.slipDisplacement;
 
-		if (
-			Math.abs(accumDistanceDisplacement) < slipDisplacement ||
-			!slipDisplacement
-		) {
-			var value = positionToValue(
-				confined,
-				this.optionsArray,
-				this.props.sliderLength,
-			);
-			var snapped = valueToPosition(
-				value,
-				this.optionsArray,
-				this.props.sliderLength,
-			);
+    if (
+      Math.abs(accumDistanceDisplacement) < slipDisplacement ||
+      !slipDisplacement
+    ) {
+      var value = positionToValue(
+        confined,
+        this.optionsArray,
+        this.props.sliderLength,
+      );
+      var snapped = valueToPosition(
+        value,
+        this.optionsArray,
+        this.props.sliderLength,
+      );
 
-			this.setState({
-				positionTwo: this.props.snapped ? snapped : confined,
-			});
+      this.setState({
+        positionTwo: this.props.snapped ? snapped : confined,
+      });
 
-			if (value !== this.state.valueTwo) {
-				this.setState(
-					{
-						valueTwo: value,
-					},
-					() => {
-						this.props.onValuesChange([
-							this.state.valueOne,
-							this.state.valueTwo,
-						]);
-					},
-				);
-			}
-		}
-	};
+      if (value !== this.state.valueTwo) {
+        this.setState(
+          {
+            valueTwo: value,
+          },
+          () => {
+            this.props.onValuesChange([
+              this.state.valueOne,
+              this.state.valueTwo,
+            ]);
+          },
+        );
+      }
+    }
+  };
 
-	endOne = gestureState => {
-		if (gestureState.moveX === 0 && this.props.onToggleOne) {
-			this.props.onToggleOne();
-			return;
-		}
+  endOne = gestureState => {
+    if (gestureState.moveX === 0 && this.props.onToggleOne) {
+      this.props.onToggleOne();
+      return;
+    }
 
-		this.setState(
-			{
-				pastOne: this.state.positionOne,
-				onePressed: !this.state.onePressed,
-			},
-			() => {
-				var change = [this.state.valueOne];
-				if (this.state.valueTwo) {
-					change.push(this.state.valueTwo);
-				}
-				this.props.onValuesChangeFinish(change);
-			},
-		);
-	};
+    this.setState(
+      {
+        pastOne: this.state.positionOne,
+        onePressed: !this.state.onePressed,
+      },
+      () => {
+        var change = [this.state.valueOne];
+        if (this.state.valueTwo) {
+          change.push(this.state.valueTwo);
+        }
+        this.props.onValuesChangeFinish(change);
+      },
+    );
+  };
 
-	endTwo = gestureState => {
-		if (gestureState.moveX === 0 && this.props.onToggleTwo) {
-			this.props.onToggleTwo();
-			return;
-		}
+  endTwo = gestureState => {
+    if (gestureState.moveX === 0 && this.props.onToggleTwo) {
+      this.props.onToggleTwo();
+      return;
+    }
 
-		this.setState(
-			{
-				twoPressed: !this.state.twoPressed,
-				pastTwo: this.state.positionTwo,
-			},
-			() => {
-				this.props.onValuesChangeFinish([
-					this.state.valueOne,
-					this.state.valueTwo,
-				]);
-			},
-		);
-	};
+    this.setState(
+      {
+        twoPressed: !this.state.twoPressed,
+        pastTwo: this.state.positionTwo,
+      },
+      () => {
+        this.props.onValuesChangeFinish([
+          this.state.valueOne,
+          this.state.valueTwo,
+        ]);
+      },
+    );
+  };
 
-	render() {
-		const { positionOne, positionTwo } = this.state;
-		const {
-			selectedStyle,
-			unselectedStyle,
-			sliderLength,
-			markerOffsetX,
-			markerOffsetY,
-		} = this.props;
-		const twoMarkers = this.props.values.length == 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
+  render() {
+    const { positionOne, positionTwo } = this.state;
+    const {
+      selectedStyle,
+      unselectedStyle,
+      sliderLength,
+      markerOffsetX,
+      markerOffsetY,
+    } = this.props;
+    const twoMarkers = this.props.values.length == 2; // when allowOverlap, positionTwo could be 0, identified as string '0' and throwing 'RawText 0 needs to be wrapped in <Text>' error
 
-		const trackOneLength = positionOne;
-		const trackOneStyle = twoMarkers
-			? unselectedStyle
-			: selectedStyle || styles.selectedTrack;
-		const trackThreeLength = twoMarkers ? sliderLength - positionTwo : 0;
-		const trackThreeStyle = unselectedStyle;
-		const trackTwoLength = sliderLength - trackOneLength - trackThreeLength;
-		const trackTwoStyle = twoMarkers
-			? selectedStyle || styles.selectedTrack
-			: unselectedStyle;
-		const Marker = this.props.customMarker;
+    const trackOneLength = positionOne;
+    const trackOneStyle = twoMarkers
+      ? unselectedStyle
+      : selectedStyle || styles.selectedTrack;
+    const trackThreeLength = twoMarkers ? sliderLength - positionTwo : 0;
+    const trackThreeStyle = unselectedStyle;
+    const trackTwoLength = sliderLength - trackOneLength - trackThreeLength;
+    const trackTwoStyle = twoMarkers
+      ? selectedStyle || styles.selectedTrack
+      : unselectedStyle;
+    const Marker = this.props.customMarker;
 
-		const MarkerLeft = this.props.customMarkerLeft;
-		const MarkerRight = this.props.customMarkerRight;
-		const isMarkersSeparated = this.props.isMarkersSeparated || false;
+    const MarkerLeft = this.props.customMarkerLeft;
+    const MarkerRight = this.props.customMarkerRight;
+    const isMarkersSeparated = this.props.isMarkersSeparated || false;
 
-		const {
-			slipDisplacement,
-			height,
-			width,
-			borderRadius,
-		} = this.props.touchDimensions;
-		const touchStyle = {
-			borderRadius: borderRadius || 0,
-		};
+    const {
+      slipDisplacement,
+      height,
+      width,
+      borderRadius,
+    } = this.props.touchDimensions;
+    const touchStyle = {
+      borderRadius: borderRadius || 0,
+    };
 
-		const markerContainerOne = {
-			top: markerOffsetY - 24,
-			left: trackOneLength + markerOffsetX - 24,
-		};
+    const markerContainerOne = {
+      top: markerOffsetY - 24,
+      left: trackOneLength + markerOffsetX - 24,
+    };
 
-		const markerContainerTwo = {
-			top: markerOffsetY - 24,
-			right: trackThreeLength + markerOffsetX - 24,
-		};
+    const markerContainerTwo = {
+      top: markerOffsetY - 24,
+      right: trackThreeLength + markerOffsetX - 24,
+    };
 
-		const containerStyle = [styles.container, this.props.containerStyle];
+    const containerStyle = [styles.container, this.props.containerStyle];
 
-		if (this.props.vertical) {
-			containerStyle.push({
-				transform: [{ rotate: '-90deg' }],
-			});
-		}
+    if (this.props.vertical) {
+      containerStyle.push({
+        transform: [{ rotate: '-90deg' }],
+      });
+    }
 
-		return (
-			<View style={containerStyle}>
-				<View style={[styles.fullTrack, { width: sliderLength }]}>
-					<View
-						style={[
-							styles.track,
-							this.props.trackStyle,
-							trackOneStyle,
-							{ width: trackOneLength },
-						]}
-					/>
-					<View
-						style={[
-							styles.track,
-							this.props.trackStyle,
-							trackTwoStyle,
-							{ width: trackTwoLength },
-						]}
-					/>
-					{twoMarkers && (
-						<View
-							style={[
-								styles.track,
-								this.props.trackStyle,
-								trackThreeStyle,
-								{ width: trackThreeLength },
-							]}
-						/>
-					)}
-					<View
-						style={[
-							styles.markerContainer,
-							markerContainerOne,
-							this.props.markerContainerStyle,
-							positionOne > sliderLength / 2 && styles.topMarkerContainer,
-						]}
-					>
-						<View
-							style={[styles.touch, touchStyle]}
-							ref={component => (this._markerOne = component)}
-							{...this._panResponderOne.panHandlers}
-						>
-							{isMarkersSeparated === false ? (
-								<Marker
-									enabled={this.props.enabledOne}
-									pressed={this.state.onePressed}
-									markerStyle={[styles.marker, this.props.markerStyle]}
-									pressedMarkerStyle={this.props.pressedMarkerStyle}
-									currentValue={this.state.valueOne}
-									valuePrefix={this.props.valuePrefix}
-									valueSuffix={this.props.valueSuffix}
-								/>
-							) : (
-									<MarkerLeft
-										enabled={this.props.enabledOne}
-										pressed={this.state.onePressed}
-										markerStyle={[styles.marker, this.props.markerStyle]}
-										pressedMarkerStyle={this.props.pressedMarkerStyle}
-										currentValue={this.state.valueOne}
-										valuePrefix={this.props.valuePrefix}
-										valueSuffix={this.props.valueSuffix}
-									/>
-								)}
-						</View>
-					</View>
-					{twoMarkers &&
-						positionOne !== this.props.sliderLength && (
-							<View
-								style={[
-									styles.markerContainer,
-									markerContainerTwo,
-									this.props.markerContainerStyle,
-								]}
-							>
-								<View
-									style={[styles.touch, touchStyle]}
-									ref={component => (this._markerTwo = component)}
-									{...this._panResponderTwo.panHandlers}
-								>
-									{isMarkersSeparated === false ? (
-										<Marker
-											pressed={this.state.twoPressed}
-											markerStyle={this.props.markerStyle}
-											pressedMarkerStyle={this.props.pressedMarkerStyle}
-											currentValue={this.state.valueTwo}
-											enabled={this.props.enabledTwo}
-											valuePrefix={this.props.valuePrefix}
-											valueSuffix={this.props.valueSuffix}
-										/>
-									) : (
-											<MarkerRight
-												pressed={this.state.twoPressed}
-												markerStyle={this.props.markerStyle}
-												pressedMarkerStyle={this.props.pressedMarkerStyle}
-												currentValue={this.state.valueTwo}
-												enabled={this.props.enabledTwo}
-												valuePrefix={this.props.valuePrefix}
-												valueSuffix={this.props.valueSuffix}
-											/>
-										)}
-								</View>
-							</View>
-						)}
-				</View>
-			</View>
-		);
-	}
+    return (
+      <View style={containerStyle}>
+        <View style={[styles.fullTrack, { width: sliderLength }]}>
+          <View
+            style={[
+              styles.track,
+              this.props.trackStyle,
+              trackOneStyle,
+              { width: trackOneLength },
+            ]}
+          />
+          <View
+            style={[
+              styles.track,
+              this.props.trackStyle,
+              trackTwoStyle,
+              { width: trackTwoLength },
+            ]}
+          />
+          {twoMarkers && (
+            <View
+              style={[
+                styles.track,
+                this.props.trackStyle,
+                trackThreeStyle,
+                { width: trackThreeLength },
+              ]}
+            />
+          )}
+          <View
+            style={[
+              styles.markerContainer,
+              markerContainerOne,
+              this.props.markerContainerStyle,
+              positionOne > sliderLength / 2 && styles.topMarkerContainer,
+            ]}
+          >
+            <View
+              style={[styles.touch, touchStyle]}
+              ref={component => (this._markerOne = component)}
+              {...this._panResponderOne.panHandlers}
+            >
+              {isMarkersSeparated === false ? (
+                <Marker
+                  enabled={this.props.enabledOne}
+                  pressed={this.state.onePressed}
+                  markerStyle={[styles.marker, this.props.markerStyle]}
+                  pressedMarkerStyle={this.props.pressedMarkerStyle}
+                  currentValue={this.state.valueOne}
+                  valuePrefix={this.props.valuePrefix}
+                  valueSuffix={this.props.valueSuffix}
+                />
+              ) : (
+                <MarkerLeft
+                  enabled={this.props.enabledOne}
+                  pressed={this.state.onePressed}
+                  markerStyle={[styles.marker, this.props.markerStyle]}
+                  pressedMarkerStyle={this.props.pressedMarkerStyle}
+                  currentValue={this.state.valueOne}
+                  valuePrefix={this.props.valuePrefix}
+                  valueSuffix={this.props.valueSuffix}
+                />
+              )}
+            </View>
+          </View>
+          {twoMarkers &&
+            positionOne !== this.props.sliderLength && (
+              <View
+                style={[
+                  styles.markerContainer,
+                  markerContainerTwo,
+                  this.props.markerContainerStyle,
+                ]}
+              >
+                <View
+                  style={[styles.touch, touchStyle]}
+                  ref={component => (this._markerTwo = component)}
+                  {...this._panResponderTwo.panHandlers}
+                >
+                  {isMarkersSeparated === false ? (
+                    <Marker
+                      pressed={this.state.twoPressed}
+                      markerStyle={this.props.markerStyle}
+                      pressedMarkerStyle={this.props.pressedMarkerStyle}
+                      currentValue={this.state.valueTwo}
+                      enabled={this.props.enabledTwo}
+                      valuePrefix={this.props.valuePrefix}
+                      valueSuffix={this.props.valueSuffix}
+                    />
+                  ) : (
+                    <MarkerRight
+                      pressed={this.state.twoPressed}
+                      markerStyle={this.props.markerStyle}
+                      pressedMarkerStyle={this.props.pressedMarkerStyle}
+                      currentValue={this.state.valueTwo}
+                      enabled={this.props.enabledTwo}
+                      valuePrefix={this.props.valuePrefix}
+                      valueSuffix={this.props.valueSuffix}
+                    />
+                  )}
+                </View>
+              </View>
+            )}
+        </View>
+      </View>
+    );
+  }
 }
 
 const styles = StyleSheet.create({
-	container: {
-		position: 'relative',
-		height: 50,
-		justifyContent: 'center',
-	},
-	fullTrack: {
-		flexDirection: 'row',
-	},
-	track: {
-		...Platform.select({
-			ios: {
-				height: 2,
-				borderRadius: 2,
-				backgroundColor: '#A7A7A7',
-			},
-			android: {
-				height: 2,
-				backgroundColor: '#CECECE',
-			},
-		}),
-	},
-	selectedTrack: {
-		...Platform.select({
-			ios: {
-				backgroundColor: '#095FFF',
-			},
-			android: {
-				backgroundColor: '#0D8675',
-			},
-		}),
-	},
-	markerContainer: {
-		position: 'absolute',
-		width: 48,
-		height: 48,
-		backgroundColor: 'transparent',
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-	topMarkerContainer: {
-		zIndex: 1,
-	},
-	touch: {
-		backgroundColor: 'transparent',
-		justifyContent: 'center',
-		alignItems: 'center',
-		alignSelf: 'stretch',
-	},
+  container: {
+    position: 'relative',
+    height: 50,
+    justifyContent: 'center',
+  },
+  fullTrack: {
+    flexDirection: 'row',
+  },
+  track: {
+    ...Platform.select({
+      ios: {
+        height: 2,
+        borderRadius: 2,
+        backgroundColor: '#A7A7A7',
+      },
+      android: {
+        height: 2,
+        backgroundColor: '#CECECE',
+      },
+    }),
+  },
+  selectedTrack: {
+    ...Platform.select({
+      ios: {
+        backgroundColor: '#095FFF',
+      },
+      android: {
+        backgroundColor: '#0D8675',
+      },
+    }),
+  },
+  markerContainer: {
+    position: 'absolute',
+    width: 48,
+    height: 48,
+    backgroundColor: 'transparent',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  topMarkerContainer: {
+    zIndex: 1,
+  },
+  touch: {
+    backgroundColor: 'transparent',
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+  },
 });

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -102,7 +102,8 @@ export default class MultiSlider extends React.Component {
     let nextState = {};
     if (
       nextProps.min !== this.props.min ||
-      nextProps.max !== this.props.max ||
+	  nextProps.max !== this.props.max ||
+	  nextProps.step !== this.props.step ||
       nextProps.values[0] !== this.state.valueOne ||
       nextProps.sliderLength !== this.props.sliderLength ||
       nextProps.values[1] !== this.state.valueTwo ||

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Feel free to contribute to this part of the documentation.
 | min | 0 | number | Minimum value available in the slider. |
 | max | 10 | number | Maximum value available in the slider. |
 | step | 1 | number | Step value of the slider. |
-| optionsArray |  | array | (?) |
+| optionsArray |  | array of numbers | Possible values of the slider. Ignores min and max. |
 | {container/track/selected/unselected/ markerContainer/marker/pressedMarker} Style |  | style object | Styles for the slider |
 | valuePrefix |  | string | Prefix added to the value. |
 | valueSuffix |  | string | Suffix added to the value. |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Options to customize track, touch area and provide customer markers and callback
 ## Examples
 
 ```
-cd example
+cd example/Basic
 npm install
 react-native run-ios
 react-native run-android

--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Feel free to contribute to this part of the documentation.
 | snapped | false | boolean | Use this when you want a fixed position for your markers, this will split the slider in N specific positions |
 | markerOffsetX | 0 | number | Offset first cursor. |
 | markerOffsetY | 0 | number | Offset second cursor. |
-| minMarkerOverlapDistance | 0 | number | if defined and more than 0, and allowOverlap is set to false, we will use this number to calculate the closest the cursors can come together, rather than use the default step length. This is useful for cases where developers need to prioritize cursors not overlapping over cursors having to be one step length from each other |
+| minMarkerOverlapDistance | 0 | number | if this is > 0 and allowOverlap is false, this value will determine the closest two markers can come to each other. This can be used for cases where you have two markers large cursors and you don't want them to overlap. Note that markers will still overlap at the start if starting values are too near. |

--- a/README.md
+++ b/README.md
@@ -96,4 +96,4 @@ Feel free to contribute to this part of the documentation.
 | snapped | false | boolean | Use this when you want a fixed position for your markers, this will split the slider in N specific positions |
 | markerOffsetX | 0 | number | Offset first cursor. |
 | markerOffsetY | 0 | number | Offset second cursor. |
-| minMarkerOverlapDistance | 0 | number | if defined and more than 0 and allowOverlap set to true, we will use this distance to calculate the overlap distance between the two markers, rather than use the default step length. |
+| minMarkerOverlapDistance | 0 | number | if defined and more than 0, and allowOverlap is set to false, we will use this number to calculate the closest the cursors can come together, rather than use the default step length. This is useful for cases where developers need to prioritize cursors not overlapping over cursors having to be one step length from each other |

--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ Feel free to contribute to this part of the documentation.
 | snapped | false | boolean | Use this when you want a fixed position for your markers, this will split the slider in N specific positions |
 | markerOffsetX | 0 | number | Offset first cursor. |
 | markerOffsetY | 0 | number | Offset second cursor. |
+| minMarkerOverlapDistance | 0 | number | if defined and more than 0 and allowOverlap set to true, we will use this distance to calculate the overlap distance between the two markers, rather than use the default step length. |

--- a/examples/Basic/App.js
+++ b/examples/Basic/App.js
@@ -8,140 +8,167 @@
 
 import React from 'react';
 
-import { StyleSheet, View, Text, Slider, Image, Platform } from 'react-native';
+import { StyleSheet, View, Text, Slider } from 'react-native';
 
 import MultiSlider from 'react-native-multi-slider';
 import CustomMarker from './CustomMarker';
 
 class App extends React.Component {
-  state = {
-    sliderOneChanging: false,
-    sliderOneValue: [5],
-    multiSliderValue: [3, 7],
-  };
+    state = {
+        sliderOneChanging: false,
+        sliderOneValue: [5],
+        multiSliderValue: [3, 7],
+        nonCollidingMultiSliderValue: [0, 100],
+    };
 
-  sliderOneValuesChangeStart = () => {
-    this.setState({
-      sliderOneChanging: true,
-    });
-  };
+    sliderOneValuesChangeStart = () => {
+        this.setState({
+            sliderOneChanging: true,
+        });
+    };
 
-  sliderOneValuesChange = values => {
-    let newValues = [0];
-    newValues[0] = values[0];
-    this.setState({
-      sliderOneValue: newValues,
-    });
-  };
+    sliderOneValuesChange = values => {
+        let newValues = [0];
+        newValues[0] = values[0];
+        this.setState({
+            sliderOneValue: newValues,
+        });
+    };
 
-  sliderOneValuesChangeFinish = () => {
-    this.setState({
-      sliderOneChanging: false,
-    });
-  };
+    sliderOneValuesChangeFinish = () => {
+        this.setState({
+            sliderOneChanging: false,
+        });
+    };
 
-  multiSliderValuesChange = values => {
-    this.setState({
-      multiSliderValue: values,
-    });
-  };
+    multiSliderValuesChange = values => {
+        this.setState({
+            multiSliderValue: values,
+        });
+    };
 
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.title}>Sliders</Text>
-        <View style={styles.sliders}>
-          <View style={styles.sliderOne}>
-            <Text style={styles.text}>One Marker with callback example:</Text>
-            <Text
-              style={[
-                styles.text,
-                this.state.sliderOneChanging && { color: 'red' },
-              ]}
-            >
-              {this.state.sliderOneValue}
-            </Text>
-          </View>
-          <MultiSlider
-            values={this.state.sliderOneValue}
-            sliderLength={280}
-            onValuesChangeStart={this.sliderOneValuesChangeStart}
-            onValuesChange={this.sliderOneValuesChange}
-            onValuesChangeFinish={this.sliderOneValuesChangeFinish}
-          />
-          <View style={styles.sliderOne}>
-            <Text style={styles.text}>Two Markers:</Text>
-            <Text style={styles.text}>{this.state.multiSliderValue[0]} </Text>
-            <Text style={styles.text}>{this.state.multiSliderValue[1]}</Text>
-          </View>
-          <MultiSlider
-            values={[
-              this.state.multiSliderValue[0],
-              this.state.multiSliderValue[1],
-            ]}
-            sliderLength={280}
-            onValuesChange={this.multiSliderValuesChange}
-            min={0}
-            max={10}
-            step={1}
-            allowOverlap
-            snapped
-          />
-        </View>
-        <Text style={styles.text}>Native RCT Slider</Text>
-        <Slider style={{ width: 280 }} />
-        <Text style={styles.text}>Custom Marker</Text>
-        <MultiSlider
-          selectedStyle={{
-            backgroundColor: 'gold',
-          }}
-          unselectedStyle={{
-            backgroundColor: 'silver',
-          }}
-          values={[5]}
-          containerStyle={{
-            height: 40,
-          }}
-          trackStyle={{
-            height: 10,
-            backgroundColor: 'red',
-          }}
-          touchDimensions={{
-            height: 40,
-            width: 40,
-            borderRadius: 20,
-            slipDisplacement: 40,
-          }}
-          customMarker={CustomMarker}
-          sliderLength={280}
-        />
-      </View>
-    );
-  }
+    nonCollidingMultiSliderValuesChange = values => {
+        this.setState({
+            nonCollidingMultiSliderValue: values,
+        });
+    };
+
+    render() {
+        return (
+            <View style={styles.container}>
+                <Text style={styles.title}>Sliders</Text>
+                <View style={styles.sliders}>
+                    <View style={styles.sliderOne}>
+                        <Text style={styles.text}>One Marker with callback example:</Text>
+                        <Text
+                            style={[
+                                styles.text,
+                                this.state.sliderOneChanging && { color: 'red' },
+                            ]}
+                        >
+                            {this.state.sliderOneValue}
+                        </Text>
+                    </View>
+                    <MultiSlider
+                        values={this.state.sliderOneValue}
+                        sliderLength={280}
+                        onValuesChangeStart={this.sliderOneValuesChangeStart}
+                        onValuesChange={this.sliderOneValuesChange}
+                        onValuesChangeFinish={this.sliderOneValuesChangeFinish}
+                    />
+                    <View style={styles.sliderOne}>
+                        <Text style={styles.text}>Two Markers:</Text>
+                        <Text style={styles.text}>{this.state.multiSliderValue[0]} </Text>
+                        <Text style={styles.text}>{this.state.multiSliderValue[1]}</Text>
+                    </View>
+                    <MultiSlider
+                        values={[
+                            this.state.multiSliderValue[0],
+                            this.state.multiSliderValue[1],
+                        ]}
+                        sliderLength={280}
+                        onValuesChange={this.multiSliderValuesChange}
+                        min={0}
+                        max={10}
+                        step={1}
+                        allowOverlap
+                        snapped
+                    />
+                </View>
+                <View style={styles.sliderOne}>
+                    <Text style={styles.text}>Two Markers with minimum overlap distance:</Text>
+                    <Text style={styles.text}>{this.state.nonCollidingMultiSliderValue[0]} </Text>
+                    <Text style={styles.text}>{this.state.nonCollidingMultiSliderValue[1]}</Text>
+                </View>
+                <MultiSlider
+                    values={[
+                        this.state.nonCollidingMultiSliderValue[0],
+                        this.state.nonCollidingMultiSliderValue[1],
+                    ]}
+                    sliderLength={280}
+                    onValuesChange={this.nonCollidingMultiSliderValuesChange}
+                    min={0}
+                    max={100}
+                    step={1}
+                    allowOverlap={false}
+                    snapped
+                    minMarkerOverlapDistance={40}
+                    customMarker={CustomMarker}
+                />
+                <Text style={styles.text}>Native RCT Slider</Text>
+                <Slider style={{ width: 280 }} />
+                <Text style={styles.text}>Custom Marker</Text>
+                <MultiSlider
+                    selectedStyle={{
+                        backgroundColor: 'gold',
+                    }}
+                    unselectedStyle={{
+                        backgroundColor: 'silver',
+                    }}
+                    values={[5]}
+                    containerStyle={{
+                        height: 40,
+                    }}
+                    trackStyle={{
+                        height: 10,
+                        backgroundColor: 'red',
+                    }}
+                    touchDimensions={{
+                        height: 40,
+                        width: 40,
+                        borderRadius: 20,
+                        slipDisplacement: 40,
+                    }}
+                    customMarker={CustomMarker}
+                    sliderLength={280}
+                />
+            </View>
+        );
+    }
 }
 
 export default App;
 
 var styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    flexDirection: 'column',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  sliders: {
-    margin: 20,
-    width: 280,
-  },
-  text: {
-    alignSelf: 'center',
-    paddingVertical: 20,
-  },
-  title: {
-    fontSize: 30,
-  },
-  sliderOne: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-  },
+    container: {
+        flex: 1,
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    sliders: {
+        margin: 20,
+        width: 280,
+    },
+    text: {
+        alignSelf: 'center',
+        paddingVertical: 20,
+    },
+    title: {
+        fontSize: 30,
+    },
+    sliderOne: {
+        flexDirection: 'row',
+        justifyContent: 'space-around',
+    },
 });


### PR DESCRIPTION
Fixes #63 

This prop will allow users of the library to define a distance between the two markers that is greater than the default step length. It can be used to ensure the rendered markers won't overlap each other.

Without minMarkerOverlapDistance:
![image](https://user-images.githubusercontent.com/8463743/53783040-f27e3d00-3f4a-11e9-9592-3ad79b0a59dd.png)

Setting minMarkerOverlapDistance to the slider marker's size means user cannot slide the markers closer than this defined distance.
In this image, minMarkerOverlapDistance is set to the marker size:
![image](https://user-images.githubusercontent.com/8463743/53783084-1fcaeb00-3f4b-11e9-9f7f-d35dbe5fcaa4.png)
