### PR TITLE
Remove `styles.marker` from Marker and MarkerLeft styles

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -421,7 +421,7 @@ export default class MultiSlider extends React.Component {
                 <Marker
                   enabled={this.props.enabledOne}
                   pressed={this.state.onePressed}
-                  markerStyle={[styles.marker, this.props.markerStyle]}
+                  markerStyle={this.props.markerStyle}
                   pressedMarkerStyle={this.props.pressedMarkerStyle}
                   currentValue={this.state.valueOne}
                   valuePrefix={this.props.valuePrefix}
@@ -431,7 +431,7 @@ export default class MultiSlider extends React.Component {
                 <MarkerLeft
                   enabled={this.props.enabledOne}
                   pressed={this.state.onePressed}
-                  markerStyle={[styles.marker, this.props.markerStyle]}
+                  markerStyle={this.props.markerStyle}
                   pressedMarkerStyle={this.props.pressedMarkerStyle}
                   currentValue={this.state.valueOne}
                   valuePrefix={this.props.valuePrefix}


### PR DESCRIPTION
- `styles.marker` does not exist
- The inclusion of this causes unpredictable behaviour when setting the `markerStyle` prop