### PR TITLE
Add support for ImageBackground

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -478,12 +478,12 @@ export default class MultiSlider extends React.Component {
     </React.Fragment>);
     return (
       <React.Fragment>
-        {this.props.backgroundImageSource && 
-          <ImageBackground source={this.props.backgroundImageSource} style={[{width: '100%', height: '100%'}, containerStyle]}>
+        {this.props.imageBackgroundSource && 
+          <ImageBackground source={this.props.imageBackgroundSource} style={[{width: '100%', height: '100%'}, containerStyle]}>
             {body}
           </ImageBackground>
         }
-        {!this.props.backgroundImageSource &&
+        {!this.props.imageBackgroundSource &&
           <View style={containerStyle}>
             {body}
           </View>

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -1,19 +1,16 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {
   StyleSheet,
   PanResponder,
   View,
-  TouchableHighlight,
   Platform,
   I18nManager,
+  ImageBackground
 } from 'react-native';
 
 import DefaultMarker from './DefaultMarker';
 import { createArray, valueToPosition, positionToValue } from './converters';
-
-const ViewPropTypes = require('react-native').ViewPropTypes || View.propTypes;
 
 export default class MultiSlider extends React.Component {
   static defaultProps = {
@@ -41,7 +38,7 @@ export default class MultiSlider extends React.Component {
     allowOverlap: false,
     snapped: false,
     vertical: false,
-    minMarkerOverlapDistance: 0,
+    minMarkerOverlapDistance: 0
   };
 
   constructor(props) {
@@ -375,9 +372,8 @@ export default class MultiSlider extends React.Component {
       });
     }
 
-    return (
-      <View style={containerStyle}>
-        <View style={[styles.fullTrack, { width: sliderLength }]}>
+    const body = (<React.Fragment>
+      <View style={[styles.fullTrack, { width: sliderLength }]}>
           <View
             style={[
               styles.track,
@@ -421,7 +417,7 @@ export default class MultiSlider extends React.Component {
                 <Marker
                   enabled={this.props.enabledOne}
                   pressed={this.state.onePressed}
-                  markerStyle={[styles.marker, this.props.markerStyle]}
+                  markerStyle={this.props.markerStyle}
                   pressedMarkerStyle={this.props.pressedMarkerStyle}
                   currentValue={this.state.valueOne}
                   valuePrefix={this.props.valuePrefix}
@@ -431,7 +427,7 @@ export default class MultiSlider extends React.Component {
                 <MarkerLeft
                   enabled={this.props.enabledOne}
                   pressed={this.state.onePressed}
-                  markerStyle={[styles.marker, this.props.markerStyle]}
+                  markerStyle={this.props.markerStyle}
                   pressedMarkerStyle={this.props.pressedMarkerStyle}
                   currentValue={this.state.valueOne}
                   valuePrefix={this.props.valuePrefix}
@@ -479,7 +475,20 @@ export default class MultiSlider extends React.Component {
               </View>
             )}
         </View>
-      </View>
+    </React.Fragment>);
+    return (
+      <React.Fragment>
+        {this.props.backgroundImageSource && 
+          <ImageBackground source={this.props.backgroundImageSource} style={[{width: '100%', height: '100%'}, containerStyle]}>
+            {body}
+          </ImageBackground>
+        }
+        {!this.props.backgroundImageSource &&
+          <View style={containerStyle}>
+            {body}
+          </View>
+        }
+      </React.Fragment>
     );
   }
 }

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -417,7 +417,7 @@ export default class MultiSlider extends React.Component {
                 <Marker
                   enabled={this.props.enabledOne}
                   pressed={this.state.onePressed}
-                  markerStyle={this.props.markerStyle}
+                  markerStyle={[styles.marker, this.props.markerStyle]}
                   pressedMarkerStyle={this.props.pressedMarkerStyle}
                   currentValue={this.state.valueOne}
                   valuePrefix={this.props.valuePrefix}
@@ -427,7 +427,7 @@ export default class MultiSlider extends React.Component {
                 <MarkerLeft
                   enabled={this.props.enabledOne}
                   pressed={this.state.onePressed}
-                  markerStyle={this.props.markerStyle}
+                  markerStyle={[styles.marker, this.props.markerStyle]}
                   pressedMarkerStyle={this.props.pressedMarkerStyle}
                   currentValue={this.state.valueOne}
                   valuePrefix={this.props.valuePrefix}

--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ Feel free to contribute to this part of the documentation.
 | markerOffsetX | 0 | number | Offset first cursor. |
 | markerOffsetY | 0 | number | Offset second cursor. |
 | minMarkerOverlapDistance | 0 | number | if this is > 0 and allowOverlap is false, this value will determine the closest two markers can come to each other. This can be used for cases where you have two markers large cursors and you don't want them to overlap. Note that markers will still overlap at the start if starting values are too near. |
-| backgroundImageSource | undefined | string | Specifies the source as required by [ImageBackgournd](https://facebook.github.io/react-native/docs/imagebackground)|
+| imageBackgroundSource | undefined | string | Specifies the source as required by [ImageBackground](https://facebook.github.io/react-native/docs/imagebackground)|

--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ Feel free to contribute to this part of the documentation.
 | markerOffsetX | 0 | number | Offset first cursor. |
 | markerOffsetY | 0 | number | Offset second cursor. |
 | minMarkerOverlapDistance | 0 | number | if this is > 0 and allowOverlap is false, this value will determine the closest two markers can come to each other. This can be used for cases where you have two markers large cursors and you don't want them to overlap. Note that markers will still overlap at the start if starting values are too near. |
+| backgroundImageSource | undefined | string | Specifies the source as required by [ImageBackgournd](https://facebook.github.io/react-native/docs/imagebackground)|


### PR DESCRIPTION
Adds the possibility to pass in a `backgroundImageSource` prop. This is useful when more complex background styles are required (such as a gradient or striped background)