### PR TITLE
Add `types` property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.2.0",
   "description": "Android and iOS supported pure JS slider component with multiple markers for React Native",
   "main": "MultiSlider.js",
+  "types": "index.d.ts",
   "scripts": {
     "prettier": "prettier --single-quote --trailing-comma all --bracket-spacing --write \"**/*.js\""
   },


### PR DESCRIPTION
Since we have types inside the project (and not as part of `definitely-typed` anymore) we need `types` property in package.json in order for app to discover them.