### PR TITLE
Allow creation of custom labels with personalized values for min/max

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -545,6 +545,8 @@ export default class MultiSlider extends React.Component {
           <Label
             oneMarkerValue={this.state.valueOne}
             twoMarkerValue={this.state.valueTwo}
+            minValue={this.props.min}
+            maxValue={this.props.max}
             oneMarkerLeftPosition={positionOne}
             twoMarkerLeftPosition={positionTwo}
             oneMarkerPressed={this.state.onePressed}

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,8 @@ export interface MarkerProps {
 export interface LabelProps {
     oneMarkerValue: string | number;
     twoMarkerValue: string | number;
+    minValue: number;
+    maxValue: number;
     oneMarkerLeftPosition: number;
     twoMarkerLeftPosition: number;
     oneMarkerPressed: boolean;


### PR DESCRIPTION
If you want to create a custom Label which shows "unlimited" when you reach the far end actually you cannot do it, because there is no way to know which one is the max value inside the Label component. This PR passes two additional min/max props to the Label component in order to do so.