### PR TITLE
[Marker] Move markers on opposite directions by x offset

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -417,7 +417,7 @@ export default class MultiSlider extends React.Component {
 
     const markerContainerTwo = {
       top: markerOffsetY - 24,
-      right: trackThreeLength - markerOffsetX - 24,
+      right: trackThreeLength + markerOffsetX - 24,
     };
 
     const containerStyle = [styles.container, this.props.containerStyle];

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Feel free to contribute to this part of the documentation.
 | allowOverlap | false | boolean | Allow the overlap within the cursors. |
 | snapped | false | boolean | Use this when you want a fixed position for your markers, this will split the slider in N specific positions |
 | vertical | false | boolean | Use vertical orientation instead of horizontal. |
-| markerOffsetX | 0 | number | Offset first cursor. |
-| markerOffsetY | 0 | number | Offset second cursor. |
+| markerOffsetX | 0 | number | Offset the cursor(s) on the X axis |
+| markerOffsetY | 0 | number | Offset the cursor(s) on the Y axis |
 | minMarkerOverlapDistance | 0 | number | if this is > 0 and allowOverlap is false, this value will determine the closest two markers can come to each other. This can be used for cases where you have two markers large cursors and you don't want them to overlap. Note that markers will still overlap at the start if starting values are too near. |
 | imageBackgroundSource | undefined | string | Specifies the source as required by [ImageBackground](https://facebook.github.io/react-native/docs/imagebackground)|


### PR DESCRIPTION
**Summary**

This PR fixes the way the markers are adjusted by `markerOffsetX`. Instead of moving on the same direction, markers should move on opposite directions.

This PR fixes/implements the following **bugs/features**
* [ ] `markerOffsetX` behavior
* [ ] `markerOffsetX` description on README
* [ ] `markerOffsetY` description on README

**Test plan (required)**

Before markers were moving in the same direction. A positive offset would move both markers to the right and a negative offset would move both markers to the left.

Example of `markerOffsetX=24`:
<img width="293" alt="Screen Shot 2020-04-14 at 6 51 13 PM" src="https://user-images.githubusercontent.com/4266269/79290421-ef10f100-7e80-11ea-989a-3f60fcadd689.png">

Now markers are moving on opposite directions. A positive offset will move markers inwards and a negative offset will move markers outwards.

Example of `markerOffsetX=24`:
<img width="258" alt="Screen Shot 2020-04-14 at 6 52 17 PM" src="https://user-images.githubusercontent.com/4266269/79290483-149dfa80-7e81-11ea-9eb2-cec62b6168a6.png">

**Closing issues**
Closes https://github.com/ptomasroos/react-native-multi-slider/issues/100