### PR TITLE
fixed converters/valueToPosition

### DIFF
--- a/converters.js
+++ b/converters.js
@@ -39,6 +39,8 @@ const closest = (array, n) => {
 };
 
 export function valueToPosition(value, valuesArray, sliderLength) {
+  if (value === undefined)
+    return undefined;
   const index = closest(valuesArray, value);
 
   const arrLength = valuesArray.length - 1;


### PR DESCRIPTION
The fact that this function is still returning a position when value is `undefined` was causing me an issue in **single slider** mode as under some conditions (after changing min and max values) it was setting `positionTwo` equal to `max` and then I wouldn't be able to slide to the max value.
I think it's better if it returns `undefined` when value is `undefined`
please let me know if I'm missing something here :)