### PR TITLE
Enabled usage of height and width props from Touch Dimensions on Mark…

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -408,6 +408,8 @@ export default class MultiSlider extends React.Component {
     } = this.props.touchDimensions;
     const touchStyle = {
       borderRadius: borderRadius || 0,
+      ...height && { height },
+      ...width && { width },
     };
 
     const markerContainerOne = {
@@ -624,6 +626,5 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
     justifyContent: 'center',
     alignItems: 'center',
-    alignSelf: 'stretch',
   },
 });


### PR DESCRIPTION
Don't know why this wasn't enabled before, but would be really nice if it were. The sliders markers sometimes are hard to hit and drag depending on the device, requiring the increase of width and height on the touchable area.