### PR TITLE
Feature - limit drag between minimum and maximum value

### DIFF
--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -17,10 +17,10 @@ import { createArray, valueToPosition, positionToValue } from './converters';
 export default class MultiSlider extends React.Component {
   static defaultProps = {
     values: [0],
-    onValuesChangeStart: () => {},
-    onValuesChange: values => {},
-    onValuesChangeFinish: values => {},
-    onMarkersPosition: values => {},
+    onValuesChangeStart: () => { },
+    onValuesChange: values => { },
+    onValuesChangeFinish: values => { },
+    onMarkersPosition: values => { },
     step: 1,
     min: 0,
     max: 10,
@@ -46,6 +46,7 @@ export default class MultiSlider extends React.Component {
     snapped: false,
     vertical: false,
     minMarkerOverlapDistance: 0,
+    moveLimitOne: 10,
   };
 
   constructor(props) {
@@ -140,6 +141,11 @@ export default class MultiSlider extends React.Component {
   };
 
   moveOne = gestureState => {
+    if (this.props.moveLimitOne === this.props.values[0]) {
+      if (gestureState.dx > 0)
+        return;
+    }
+
     if (!this.props.enabledOne) {
       return;
     }
@@ -160,8 +166,8 @@ export default class MultiSlider extends React.Component {
       (this.props.allowOverlap
         ? 0
         : this.props.minMarkerOverlapDistance > 0
-        ? this.props.minMarkerOverlapDistance
-        : this.stepLength);
+          ? this.props.minMarkerOverlapDistance
+          : this.stepLength);
     var top =
       trueTop === 0
         ? 0
@@ -232,8 +238,8 @@ export default class MultiSlider extends React.Component {
       (this.props.allowOverlap
         ? 0
         : this.props.minMarkerOverlapDistance > 0
-        ? this.props.minMarkerOverlapDistance
-        : this.stepLength);
+          ? this.props.minMarkerOverlapDistance
+          : this.stepLength);
     var top = this.props.sliderLength - this.props.markerSize / 2;
     var confined =
       unconfined < bottom ? bottom : unconfined > top ? top : unconfined;
@@ -500,17 +506,17 @@ export default class MultiSlider extends React.Component {
                   valueSuffix={this.props.valueSuffix}
                 />
               ) : (
-                <MarkerLeft
-                  enabled={this.props.enabledOne}
-                  pressed={this.state.onePressed}
-                  markerStyle={this.props.markerStyle}
-                  pressedMarkerStyle={this.props.pressedMarkerStyle}
-                  disabledMarkerStyle={this.props.disabledMarkerStyle}
-                  currentValue={this.state.valueOne}
-                  valuePrefix={this.props.valuePrefix}
-                  valueSuffix={this.props.valueSuffix}
-                />
-              )}
+                  <MarkerLeft
+                    enabled={this.props.enabledOne}
+                    pressed={this.state.onePressed}
+                    markerStyle={this.props.markerStyle}
+                    pressedMarkerStyle={this.props.pressedMarkerStyle}
+                    disabledMarkerStyle={this.props.disabledMarkerStyle}
+                    currentValue={this.state.valueOne}
+                    valuePrefix={this.props.valuePrefix}
+                    valueSuffix={this.props.valueSuffix}
+                  />
+                )}
             </View>
           </View>
           {twoMarkers && positionOne !== this.props.sliderLength && (
@@ -538,17 +544,17 @@ export default class MultiSlider extends React.Component {
                     valueSuffix={this.props.valueSuffix}
                   />
                 ) : (
-                  <MarkerRight
-                    pressed={this.state.twoPressed}
-                    markerStyle={this.props.markerStyle}
-                    pressedMarkerStyle={this.props.pressedMarkerStyle}
-                    disabledMarkerStyle={this.props.disabledMarkerStyle}
-                    currentValue={this.state.valueTwo}
-                    enabled={this.props.enabledTwo}
-                    valuePrefix={this.props.valuePrefix}
-                    valueSuffix={this.props.valueSuffix}
-                  />
-                )}
+                    <MarkerRight
+                      pressed={this.state.twoPressed}
+                      markerStyle={this.props.markerStyle}
+                      pressedMarkerStyle={this.props.pressedMarkerStyle}
+                      disabledMarkerStyle={this.props.disabledMarkerStyle}
+                      currentValue={this.state.valueTwo}
+                      enabled={this.props.enabledTwo}
+                      valuePrefix={this.props.valuePrefix}
+                      valueSuffix={this.props.valueSuffix}
+                    />
+                  )}
               </View>
             </View>
           )}

--- a/MultiSlider.js
+++ b/MultiSlider.js
@@ -392,6 +392,11 @@ export default class MultiSlider extends React.Component {
     }
   }
 
+  componentDidMount() {
+    const { positionOne, positionTwo } = this.state;
+    this.props.onMarkersPosition([positionOne, positionTwo]);
+  }
+
   render() {
     const { positionOne, positionTwo } = this.state;
     const {

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,6 @@ export interface LabelProps {
 
 export interface MultiSliderProps {
     values?: number[];
-
     onValuesChange?: (values: number[]) => void;
     onValuesChangeStart?: () => void;
     onValuesChangeFinish?: (values: number[]) => void;
@@ -77,6 +76,7 @@ export interface MultiSliderProps {
     imageBackgroundSource?: string;
     enableLabel?: boolean;
     vertical?: boolean;
+    moveLimitOne?: number;
 }
 
 export default class MultiSlider extends React.Component<MultiSliderProps> {}


### PR DESCRIPTION
I needed a feature that didn't exist, limiting the slip between the minimum and maximum value, example:
0, 1, 2, 3, 4, 5, 6, 7;
the limit passed as a parameter = 4;
the user can only drag from 0, 1, 2, 3, 4, but 5, 6, 7 are still present.