### PR TITLE
Center default label above marker

### DIFF
--- a/DefaultLabel.js
+++ b/DefaultLabel.js
@@ -34,7 +34,7 @@ export default class DefaultLabel extends React.Component {
             <View
               style={[
                 styles.sliderLabel,
-                { left: oneMarkerLeftPosition - width / 2 + sliderRadius },
+                { left: oneMarkerLeftPosition - width / 2 },
                 oneMarkerPressed && styles.markerPressed,
               ]}
             >
@@ -47,7 +47,7 @@ export default class DefaultLabel extends React.Component {
             <View
               style={[
                 styles.sliderLabel,
-                { left: twoMarkerLeftPosition - width / 2 + sliderRadius },
+                { left: twoMarkerLeftPosition - width / 2 },
                 twoMarkerPressed && styles.markerPressed,
               ]}
             >


### PR DESCRIPTION
The default label container view and text is not correctly centred above the marker.

<img width="333" alt="Screenshot 2021-01-03 at 17 15 39" src="https://user-images.githubusercontent.com/25026205/103483405-6576ca00-4de7-11eb-8a5c-4e309b6f7f88.png">

By removing the sliderRadius it looks perfectly centred:

<img width="334" alt="Screenshot 2021-01-03 at 17 16 30" src="https://user-images.githubusercontent.com/25026205/103483863-7bd25500-4dea-11eb-9c09-7aaaffce1ad3.png">

See also this snack: https://snack.expo.io/5Dou_n0T4